### PR TITLE
feat: complete data pipeline and analytics API (Sprints 2-6)

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -1,6 +1,14 @@
 # crud.py
 # Contains all database query logic (Create, Read, Update, Delete).
 # The routes in main.py call these functions — keeping routes clean and simple.
+#
+# Sprint history:
+#   Sprint 1-2 : get_all_actors, get_actor_by_name, get_movies_by_actor,
+#                get_actor_stats (legacy — computes from movies table)
+#   Sprint 6   : search_actors, get_actor_with_stats,
+#                get_actor_movies_enriched, get_actor_collaborators,
+#                get_actor_directors, get_actor_production,
+#                get_actor_compare_stats, get_health_counts
 
 from sqlalchemy.orm import Session
 from sqlalchemy import func
@@ -9,13 +17,20 @@ from typing import Optional
 from . import models, schemas
 
 
+# ===========================================================================
+# Core actor helpers  (used by multiple endpoints)
+# ===========================================================================
+
 def get_all_actors(db: Session):
-    """Return all actors from the database."""
+    """Return all actors from the database (used by GET /actors)."""
     return db.query(models.Actor).all()
 
 
 def get_actor_by_name(db: Session, name: str) -> Optional[models.Actor]:
-    """Find a single actor by their exact name (case-insensitive)."""
+    """
+    Find a single actor by their exact name (case-insensitive).
+    Uses the functional index idx_actors_name_lower for an indexed scan.
+    """
     return (
         db.query(models.Actor)
         .filter(func.lower(models.Actor.name) == name.lower())
@@ -23,10 +38,65 @@ def get_actor_by_name(db: Session, name: str) -> Optional[models.Actor]:
     )
 
 
+def get_actor_by_id(db: Session, actor_id: int) -> Optional[models.Actor]:
+    """Return the Actor row for a given primary key, or None."""
+    return db.query(models.Actor).filter(models.Actor.id == actor_id).first()
+
+
+# ===========================================================================
+# Search  (GET /actors/search?q=)
+# ===========================================================================
+
+def search_actors(db: Session, q: str, limit: int = 20) -> list:
+    """
+    Case-insensitive partial-match search on actors.name.
+
+    Uses ILIKE '%q%' — with a leading wildcard a btree index cannot be used,
+    but with only ~13 actors in the table a sequential scan completes in < 1 ms.
+    Returns at most `limit` results (default 20).
+    """
+    return (
+        db.query(models.Actor.id, models.Actor.name)
+        .filter(models.Actor.name.ilike(f"%{q}%"))
+        .order_by(models.Actor.name)
+        .limit(limit)
+        .all()
+    )
+
+
+# ===========================================================================
+# Actor profile  (GET /actors/{actor_id})
+# ===========================================================================
+
+def get_actor_with_stats(
+    db: Session, actor_id: int
+) -> Optional[tuple[models.Actor, Optional[models.ActorStats]]]:
+    """
+    Return (Actor, ActorStats | None) for the given actor_id.
+    ActorStats is read from the precomputed actor_stats table (O(1) lookup).
+    Returns None if the actor does not exist.
+    """
+    actor = get_actor_by_id(db, actor_id)
+    if not actor:
+        return None
+
+    stats = (
+        db.query(models.ActorStats)
+        .filter(models.ActorStats.actor_id == actor_id)
+        .first()
+    )
+    return actor, stats
+
+
+# ===========================================================================
+# Actor movies  (GET /actors/{actor_id}/movies)
+# ===========================================================================
+
 def get_movies_by_actor(db: Session, actor_id: int):
     """
-    Return all movies an actor appeared in.
-    We join through the Cast table to find movies linked to this actor.
+    Return all movies an actor appeared in (legacy — used by seed_data
+    and older tooling).  Not ordered; use get_actor_movies_enriched for
+    the Sprint 6 endpoint.
     """
     return (
         db.query(models.Movie)
@@ -36,36 +106,163 @@ def get_movies_by_actor(db: Session, actor_id: int):
     )
 
 
-def get_actor_stats(db: Session, actor_name: str) -> Optional[schemas.ActorStats]:
+def get_actor_movies_enriched(db: Session, actor_id: int) -> list:
     """
-    Compute analytics for a single actor:
-    - Total number of movies
-    - Average IMDb rating
-    - Number of movies released after 2015
-    - Average box office
+    Return all movies for an actor, ordered by release_year DESC.
+    Joins cast → movies and returns full Movie objects so Pydantic can
+    read the enriched fields (runtime, production_company, language).
 
-    Returns None if the actor is not found.
+    Uses the idx_cast_actor index for an efficient cast scan.
+    """
+    return (
+        db.query(models.Movie)
+        .join(models.Cast, models.Cast.movie_id == models.Movie.id)
+        .filter(models.Cast.actor_id == actor_id)
+        .order_by(models.Movie.release_year.desc())
+        .all()
+    )
+
+
+# ===========================================================================
+# Actor collaborators  (GET /actors/{actor_id}/collaborators)
+# ===========================================================================
+
+def get_actor_collaborators(db: Session, actor_id: int) -> list:
+    """
+    Return top co-stars for an actor, ordered by collaboration_count DESC.
+    Reads from the precomputed actor_collaborations table (O(1) scan per actor).
+
+    Returns a list of (name: str, collaboration_count: int) named tuples.
+    Because both directions are stored in actor_collaborations, querying
+    WHERE actor1_id = ? always returns the full collaborator set.
+
+    Uses the idx_collab_actor1 index.
+    """
+    return (
+        db.query(
+            models.Actor.name,
+            models.ActorCollaboration.collaboration_count,
+        )
+        .join(
+            models.ActorCollaboration,
+            models.ActorCollaboration.actor2_id == models.Actor.id,
+        )
+        .filter(models.ActorCollaboration.actor1_id == actor_id)
+        .order_by(models.ActorCollaboration.collaboration_count.desc())
+        .all()
+    )
+
+
+# ===========================================================================
+# Actor directors  (GET /actors/{actor_id}/directors)
+# ===========================================================================
+
+def get_actor_directors(db: Session, actor_id: int) -> list:
+    """
+    Return all directors an actor has worked with, ordered by film_count DESC.
+    Reads from the precomputed actor_director_stats table.
+    Uses the idx_director_actor index.
+    """
+    return (
+        db.query(models.ActorDirectorStat)
+        .filter(models.ActorDirectorStat.actor_id == actor_id)
+        .order_by(models.ActorDirectorStat.film_count.desc())
+        .all()
+    )
+
+
+# ===========================================================================
+# Actor production companies  (GET /actors/{actor_id}/production)
+# ===========================================================================
+
+def get_actor_production(db: Session, actor_id: int) -> list:
+    """
+    Return production companies an actor has worked with, ordered by
+    film_count DESC. Reads from the precomputed actor_production_stats table.
+    Uses the idx_production_actor index.
+    """
+    return (
+        db.query(models.ActorProductionStat)
+        .filter(models.ActorProductionStat.actor_id == actor_id)
+        .order_by(models.ActorProductionStat.film_count.desc())
+        .all()
+    )
+
+
+# ===========================================================================
+# Actor comparison  (GET /compare?actor1=...&actor2=...)
+# ===========================================================================
+
+def get_actor_compare_stats(
+    db: Session, actor_name: str
+) -> Optional[tuple[models.Actor, models.ActorStats]]:
+    """
+    Look up an actor by name and return their precomputed stats.
+    Both the actor row and the actor_stats row are required; if either is
+    missing (e.g. the analytics tables haven't been built yet) returns None.
+
+    This is the Sprint 6 compare helper — reads only two indexed rows per
+    actor (actors PK + actor_stats PK), so the response is O(1).
+    """
+    actor = get_actor_by_name(db, actor_name)
+    if not actor:
+        return None
+
+    stats = (
+        db.query(models.ActorStats)
+        .filter(models.ActorStats.actor_id == actor.id)
+        .first()
+    )
+    if not stats:
+        return None
+
+    return actor, stats
+
+
+# ===========================================================================
+# Health  (GET /health)
+# ===========================================================================
+
+def get_health_counts(db: Session) -> tuple[int, int]:
+    """
+    Return (actor_count, movie_count) for the /health endpoint.
+    Uses COUNT aggregates — fast even without dedicated indexes since
+    PostgreSQL tracks table sizes in pg_class.
+    """
+    actor_count = db.query(func.count(models.Actor.id)).scalar() or 0
+    movie_count = db.query(func.count(models.Movie.id)).scalar() or 0
+    return actor_count, movie_count
+
+
+# ===========================================================================
+# Legacy helpers  (retained for backward compatibility)
+# ===========================================================================
+
+def get_actor_stats(db: Session, actor_name: str) -> Optional[schemas.LegacyActorStats]:
+    """
+    Compute analytics for a single actor on the fly from the movies table.
+
+    LEGACY — originally used by /compare (Sprint 1-2). Kept so any tooling
+    that imports this function still works. New endpoints should call
+    get_actor_compare_stats() which reads from the precomputed actor_stats
+    table and is significantly faster.
     """
     actor = get_actor_by_name(db, actor_name)
     if not actor:
         return None
 
     movies = get_movies_by_actor(db, actor.id)
-
     total_movies = len(movies)
 
-    # Average rating — filter out movies where rating is missing
     ratings = [m.imdb_rating for m in movies if m.imdb_rating is not None]
     avg_rating = round(sum(ratings) / len(ratings), 2) if ratings else None
 
-    # Count movies released after 2015
     movies_after_2015 = sum(1 for m in movies if m.release_year > 2015)
 
-    # Average box office — filter out movies where box office is missing
     box_offices = [m.box_office for m in movies if m.box_office is not None]
     avg_box_office = round(sum(box_offices) / len(box_offices), 2) if box_offices else None
 
-    return schemas.ActorStats(
+    return schemas.LegacyActorStats(
         name=actor.name,
         total_movies=total_movies,
         avg_rating=avg_rating,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,13 @@
 #
 # Run with:
 #   uvicorn app.main:app --reload
+#
+# Sprint history:
+#   Sprint 1-2 : /health, /actors, /actors/{id}/movies, /compare
+#   Sprint 6   : /health (enriched), /actors/search, /actors/{id} (profile),
+#                /actors/{id}/movies (enriched + ordered), /actors/{id}/collaborators,
+#                /actors/{id}/directors, /actors/{id}/production,
+#                /compare (analytics-backed, O(1))
 
 from fastapi import FastAPI, Depends, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
@@ -14,18 +21,25 @@ from .database import engine, get_db
 from . import models, crud, schemas
 
 # Create all database tables on startup (safe to run multiple times).
-# This uses the models defined in models.py to create the tables.
 models.Base.metadata.create_all(bind=engine)
 
-# Create the FastAPI app instance.
+# ---------------------------------------------------------------------------
+# App instance
+# ---------------------------------------------------------------------------
+
 app = FastAPI(
     title="South Cinema Analytics API",
-    description="Compare South Indian actors by movies, ratings, and box office performance.",
-    version="1.0.0",
+    description=(
+        "Analytics API for South Indian cinema. "
+        "Query actor profiles, filmographies, collaborations, and "
+        "side-by-side comparisons powered by precomputed analytics tables."
+    ),
+    version="2.0.0",
+    docs_url="/docs",
+    redoc_url="/redoc",
 )
 
 # Allow the frontend (localhost:3000) to call the backend (localhost:8000).
-# Without this, the browser blocks cross-origin requests (CORS policy).
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["http://localhost:3000"],
@@ -34,74 +48,332 @@ app.add_middleware(
 )
 
 
-# ---------------------------------------------------------------------------
-# Health Check
-# ---------------------------------------------------------------------------
+# ===========================================================================
+# Health
+# ===========================================================================
 
-@app.get("/health")
-def health_check():
+@app.get(
+    "/health",
+    response_model=schemas.HealthOut,
+    summary="API health check",
+    tags=["Health"],
+)
+def health_check(db: Session = Depends(get_db)):
     """
-    Simple health check endpoint.
-    Returns { "status": "ok" } if the server is running.
+    Returns the service status plus live row counts.
+
+    Example response:
+    ```json
+    { "status": "ok", "actors": 13, "movies": 734 }
+    ```
     """
-    return {"status": "ok"}
+    actor_count, movie_count = crud.get_health_counts(db)
+    return schemas.HealthOut(status="ok", actors=actor_count, movies=movie_count)
 
 
-# ---------------------------------------------------------------------------
-# Actor Endpoints
-# ---------------------------------------------------------------------------
+# ===========================================================================
+# Actor endpoints
+# ===========================================================================
 
-@app.get("/actors", response_model=List[schemas.ActorOut])
+@app.get(
+    "/actors/search",
+    response_model=List[schemas.ActorSearchResult],
+    summary="Search actors by name",
+    tags=["Actors"],
+)
+def search_actors(
+    q: str = Query(..., min_length=1, description="Partial actor name to search for"),
+    db: Session = Depends(get_db),
+):
+    """
+    Case-insensitive partial-match search on actor names. Returns at most 20 results.
+
+    Example:
+    ```
+    GET /actors/search?q=vij
+    ```
+    ```json
+    [
+      { "id": 7, "name": "Vijay" }
+    ]
+    ```
+    """
+    results = crud.search_actors(db, q)
+    return [schemas.ActorSearchResult(id=row.id, name=row.name) for row in results]
+
+
+@app.get(
+    "/actors",
+    response_model=List[schemas.ActorOut],
+    summary="List all actors",
+    tags=["Actors"],
+)
 def list_actors(db: Session = Depends(get_db)):
     """
-    Returns a list of all actors in the database.
-    Example: GET /actors
+    Returns every actor in the database (id, name, industry, debut_year).
+
+    Example:
+    ```
+    GET /actors
+    ```
     """
-    actors = crud.get_all_actors(db)
-    return actors
+    return crud.get_all_actors(db)
 
 
-@app.get("/actors/{actor_id}/movies", response_model=List[schemas.MovieOut])
-def get_actor_movies(actor_id: int, db: Session = Depends(get_db)):
+@app.get(
+    "/actors/{actor_id}",
+    response_model=schemas.ActorProfile,
+    summary="Actor profile with career stats",
+    tags=["Actors"],
+)
+def get_actor_profile(actor_id: int, db: Session = Depends(get_db)):
     """
-    Returns all movies for a specific actor by their ID.
-    Example: GET /actors/1/movies
+    Returns an actor's profile enriched with precomputed career statistics.
+    Stats are read from the **actor_stats** analytics table — O(1) lookup.
+
+    Example:
+    ```
+    GET /actors/12
+    ```
+    ```json
+    {
+      "id": 12,
+      "name": "Rajinikanth",
+      "industry": "Tamil",
+      "film_count": 157,
+      "first_film_year": 1957,
+      "last_film_year": 2025,
+      "avg_runtime": 170.0
+    }
+    ```
+
+    Run `python -m data_pipeline.build_analytics_tables` if `film_count` is 0.
     """
-    # Check the actor exists first
-    actor = db.query(models.Actor).filter(models.Actor.id == actor_id).first()
-    if not actor:
+    result = crud.get_actor_with_stats(db, actor_id)
+    if result is None:
         raise HTTPException(status_code=404, detail="Actor not found")
 
-    movies = crud.get_movies_by_actor(db, actor_id)
+    actor, stats = result
+    return schemas.ActorProfile(
+        id=actor.id,
+        name=actor.name,
+        industry=actor.industry,
+        film_count=stats.film_count if stats else 0,
+        first_film_year=stats.first_film_year if stats else None,
+        last_film_year=stats.last_film_year if stats else None,
+        avg_runtime=round(stats.avg_runtime, 1) if stats and stats.avg_runtime else None,
+    )
+
+
+@app.get(
+    "/actors/{actor_id}/movies",
+    response_model=List[schemas.ActorMovieOut],
+    summary="Movies an actor appeared in",
+    tags=["Actors"],
+)
+def get_actor_movies(actor_id: int, db: Session = Depends(get_db)):
+    """
+    Returns all movies the actor has appeared in, ordered newest-first.
+    Enriched fields (runtime, production_company, language) are populated by
+    `python -m data_pipeline.enrich_movies`.
+
+    Example:
+    ```
+    GET /actors/12/movies
+    ```
+    ```json
+    [
+      {
+        "title": "Jailer",
+        "release_year": 2023,
+        "director": "Nelson Dilipkumar",
+        "runtime": 168,
+        "production_company": "Sun Pictures",
+        "language": "Tamil"
+      },
+      ...
+    ]
+    ```
+    """
+    if not crud.get_actor_by_id(db, actor_id):
+        raise HTTPException(status_code=404, detail="Actor not found")
+
+    movies = crud.get_actor_movies_enriched(db, actor_id)
     return movies
 
 
-# ---------------------------------------------------------------------------
-# Comparison Endpoint
-# ---------------------------------------------------------------------------
+@app.get(
+    "/actors/{actor_id}/collaborators",
+    response_model=List[schemas.CollaboratorOut],
+    summary="Top co-stars for an actor",
+    tags=["Actors"],
+)
+def get_actor_collaborators(actor_id: int, db: Session = Depends(get_db)):
+    """
+    Returns actors who have appeared in the most films alongside this actor,
+    sorted by collaboration count (descending).
+    Reads from the **actor_collaborations** precomputed table — O(1) per actor.
 
-@app.get("/compare", response_model=schemas.CompareResponse)
+    Example:
+    ```
+    GET /actors/12/collaborators
+    ```
+    ```json
+    [
+      { "actor": "Kamal Haasan", "films": 12 },
+      { "actor": "Sridevi", "films": 8 }
+    ]
+    ```
+    """
+    if not crud.get_actor_by_id(db, actor_id):
+        raise HTTPException(status_code=404, detail="Actor not found")
+
+    rows = crud.get_actor_collaborators(db, actor_id)
+    return [
+        schemas.CollaboratorOut(actor=name, films=count)
+        for name, count in rows
+    ]
+
+
+@app.get(
+    "/actors/{actor_id}/directors",
+    response_model=List[schemas.DirectorCollabOut],
+    summary="Directors an actor has worked with",
+    tags=["Actors"],
+)
+def get_actor_directors(actor_id: int, db: Session = Depends(get_db)):
+    """
+    Returns directors sorted by number of films made with this actor.
+    Reads from the **actor_director_stats** precomputed table.
+
+    Example:
+    ```
+    GET /actors/12/directors
+    ```
+    ```json
+    [
+      { "director": "S. P. Muthuraman", "films": 23 },
+      { "director": "Shankar", "films": 4 }
+    ]
+    ```
+    """
+    if not crud.get_actor_by_id(db, actor_id):
+        raise HTTPException(status_code=404, detail="Actor not found")
+
+    rows = crud.get_actor_directors(db, actor_id)
+    return [
+        schemas.DirectorCollabOut(director=row.director, films=row.film_count)
+        for row in rows
+    ]
+
+
+@app.get(
+    "/actors/{actor_id}/production",
+    response_model=List[schemas.ProductionOut],
+    summary="Production companies an actor has worked with",
+    tags=["Actors"],
+)
+def get_actor_production(actor_id: int, db: Session = Depends(get_db)):
+    """
+    Returns production companies sorted by number of films made with this actor.
+    Populated only after running `python -m data_pipeline.enrich_movies`.
+    Reads from the **actor_production_stats** precomputed table.
+
+    Example:
+    ```
+    GET /actors/12/production
+    ```
+    ```json
+    [
+      { "company": "Sun Pictures", "films": 2 }
+    ]
+    ```
+    """
+    if not crud.get_actor_by_id(db, actor_id):
+        raise HTTPException(status_code=404, detail="Actor not found")
+
+    rows = crud.get_actor_production(db, actor_id)
+    return [
+        schemas.ProductionOut(company=row.production_company, films=row.film_count)
+        for row in rows
+    ]
+
+
+# ===========================================================================
+# Comparison endpoint
+# ===========================================================================
+
+@app.get(
+    "/compare",
+    response_model=schemas.CompareResponse,
+    summary="Side-by-side actor comparison",
+    tags=["Compare"],
+)
 def compare_actors(
     actor1: str = Query(..., description="Full name of the first actor"),
     actor2: str = Query(..., description="Full name of the second actor"),
     db: Session = Depends(get_db),
 ):
     """
-    Compares two actors side by side using analytics.
-    Example: GET /compare?actor1=Allu Arjun&actor2=Vijay
+    Compares two actors side by side.
+    Stats are read from the **actor_stats** precomputed table — O(1) per actor.
 
-    Returns stats for each actor:
-    - Total movies
-    - Average IMDb rating
-    - Movies released after 2015
-    - Average box office (in crores)
+    Example:
+    ```
+    GET /compare?actor1=Rajinikanth&actor2=Kamal Haasan
+    ```
+    ```json
+    {
+      "actor1": {
+        "name": "Rajinikanth",
+        "films": 157,
+        "avg_runtime": 170.0,
+        "first_film": 1957,
+        "last_film": 2025
+      },
+      "actor2": {
+        "name": "Kamal Haasan",
+        "films": 174,
+        "avg_runtime": 182.0,
+        "first_film": 1957,
+        "last_film": 2024
+      }
+    }
+    ```
+
+    Returns HTTP 404 if either actor is not found, or if the analytics tables
+    have not been built yet (`python -m data_pipeline.build_analytics_tables`).
     """
-    stats1 = crud.get_actor_stats(db, actor1)
-    if not stats1:
-        raise HTTPException(status_code=404, detail=f"Actor '{actor1}' not found")
+    result1 = crud.get_actor_compare_stats(db, actor1)
+    if not result1:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Actor '{actor1}' not found or analytics not built yet.",
+        )
 
-    stats2 = crud.get_actor_stats(db, actor2)
-    if not stats2:
-        raise HTTPException(status_code=404, detail=f"Actor '{actor2}' not found")
+    result2 = crud.get_actor_compare_stats(db, actor2)
+    if not result2:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Actor '{actor2}' not found or analytics not built yet.",
+        )
 
-    return schemas.CompareResponse(actor1=stats1, actor2=stats2)
+    a1, s1 = result1
+    a2, s2 = result2
+
+    return schemas.CompareResponse(
+        actor1=schemas.ActorCompareStats(
+            name=a1.name,
+            films=s1.film_count,
+            avg_runtime=round(s1.avg_runtime, 1) if s1.avg_runtime else None,
+            first_film=s1.first_film_year,
+            last_film=s1.last_film_year,
+        ),
+        actor2=schemas.ActorCompareStats(
+            name=a2.name,
+            films=s2.film_count,
+            avg_runtime=round(s2.avg_runtime, 1) if s2.avg_runtime else None,
+            first_film=s2.first_film_year,
+            last_film=s2.last_film_year,
+        ),
+    )

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,11 +1,28 @@
 # models.py
 # Defines the database tables as Python classes using SQLAlchemy.
 # Each class = one table in PostgreSQL.
+#
+# Schema (Sprint 4):
+#
+#   actor_registry  (seed catalog — Wikidata QIDs for bulk ingestion)
+#   pipeline_runs   (audit log — tracks every ingestion/enrichment run)
+#
+#   actors  ──<  cast  >──  movies  ──<  movie_directors  >──  directors
+#
+# The "cast" table is the actor↔movie join table (many-to-many).
+# The "movie_directors" table is the movie↔director join table (many-to-many),
+# replacing the legacy movies.director TEXT column which is kept for backward
+# compatibility but should not be used for new analytics queries.
 
-from sqlalchemy import Column, Integer, String, Float, ForeignKey
+from sqlalchemy import Column, DateTime, Integer, String, Float, ForeignKey, Text
 from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
 from .database import Base
 
+
+# ---------------------------------------------------------------------------
+# Actor
+# ---------------------------------------------------------------------------
 
 class Actor(Base):
     """
@@ -14,32 +31,77 @@ class Actor(Base):
     """
     __tablename__ = "actors"
 
-    id = Column(Integer, primary_key=True, index=True)
-    name = Column(String, unique=True, nullable=False)       # e.g. "Allu Arjun"
-    industry = Column(String, nullable=False)                # e.g. "Telugu", "Tamil"
-    debut_year = Column(Integer, nullable=True)              # e.g. 2003
+    id          = Column(Integer, primary_key=True, index=True)
+    name        = Column(String,  unique=True, nullable=False)   # e.g. "Allu Arjun"
+    industry    = Column(String,  nullable=False)                 # e.g. "Telugu", "Tamil"
+    debut_year  = Column(Integer, nullable=True)                  # e.g. 2003
 
-    # Relationship: Actor -> Cast -> Movie
+    # Relationship: Actor → Cast → Movie
     cast_entries = relationship("Cast", back_populates="actor")
 
+
+# ---------------------------------------------------------------------------
+# Movie
+# ---------------------------------------------------------------------------
 
 class Movie(Base):
     """
     Represents a South Indian film.
-    One movie can have many actors (through the Cast table).
+    One movie can have many actors (Cast) and many directors (MovieDirector).
+
+    Legacy column `director` (TEXT) is kept for backward compatibility with
+    existing API endpoints and seed data.  New code must use the normalized
+    `movie_director_entries` / Director model instead.
     """
     __tablename__ = "movies"
 
-    id = Column(Integer, primary_key=True, index=True)
-    title = Column(String, nullable=False)                   # e.g. "Pushpa"
-    release_year = Column(Integer, nullable=False)           # e.g. 2021
-    imdb_rating = Column(Float, nullable=True)               # e.g. 7.6
-    box_office = Column(Float, nullable=True)                # in crores (INR)
-    industry = Column(String, nullable=False)                # e.g. "Telugu"
+    id                 = Column(Integer, primary_key=True, index=True)
+    title              = Column(String,  nullable=False)           # e.g. "Pushpa"
+    release_year       = Column(Integer, nullable=False)           # e.g. 2021
+    imdb_rating        = Column(Float,   nullable=True)            # e.g. 7.6
+    box_office         = Column(Float,   nullable=True)            # in crores (INR)
+    industry           = Column(String,  nullable=False)           # e.g. "Telugu"
 
-    # Relationship: Movie -> Cast -> Actor
+    # ------------------------------------------------------------------
+    # Legacy TEXT column — kept for backward compatibility.
+    # DO NOT remove until all API consumers use the normalized tables.
+    # ------------------------------------------------------------------
+    director           = Column(String,  nullable=True)            # e.g. "Sukumar" (denormalized)
+
+    # Rich-media fields (populated by TMDB / Wikipedia clients)
+    poster_url         = Column(String,  nullable=True)            # TMDB poster image URL
+    backdrop_url       = Column(String,  nullable=True)            # TMDB backdrop image URL
+    production_company = Column(String,  nullable=True)            # e.g. "Mythri Movie Makers"
+    runtime            = Column(Integer, nullable=True)            # duration in minutes
+    language           = Column(String,  nullable=True)            # e.g. "Telugu", "Tamil"
+
+    # Relationship: Movie → Cast → Actor
     cast_entries = relationship("Cast", back_populates="movie")
 
+    # Relationship: Movie → MovieDirector → Director  (normalized, Sprint 2)
+    # Navigate via:  movie.movie_director_entries[n].director
+    # or use the convenience property below.
+    movie_director_entries = relationship(
+        "MovieDirector",
+        back_populates="movie",
+        cascade="all, delete-orphan",   # removing a movie cleans up its join rows
+    )
+
+    @property
+    def director_names(self) -> list[str]:
+        """
+        Convenience property: returns a list of director name strings.
+        Avoids exposing the join-table internals to calling code.
+
+        Example:
+            movie.director_names  →  ["Sukumar"]
+        """
+        return [entry.director.name for entry in self.movie_director_entries]
+
+
+# ---------------------------------------------------------------------------
+# Cast  (actor ↔ movie join table)
+# ---------------------------------------------------------------------------
 
 class Cast(Base):
     """
@@ -48,11 +110,235 @@ class Cast(Base):
     """
     __tablename__ = "cast"
 
-    id = Column(Integer, primary_key=True, index=True)
-    actor_id = Column(Integer, ForeignKey("actors.id"), nullable=False)
-    movie_id = Column(Integer, ForeignKey("movies.id"), nullable=False)
-    role_type = Column(String, nullable=True)                # e.g. "Lead", "Supporting"
+    id        = Column(Integer, primary_key=True, index=True)
+    actor_id  = Column(Integer, ForeignKey("actors.id"),  nullable=False)
+    movie_id  = Column(Integer, ForeignKey("movies.id"),  nullable=False)
+    role_type = Column(String,  nullable=True)             # e.g. "Lead", "Supporting"
 
-    # Back-references so we can navigate: cast.actor or cast.movie
+    # Back-references so we can navigate: cast.actor  /  cast.movie
     actor = relationship("Actor", back_populates="cast_entries")
     movie = relationship("Movie", back_populates="cast_entries")
+
+
+# ---------------------------------------------------------------------------
+# Director  (Sprint 2 — normalized)
+# ---------------------------------------------------------------------------
+
+class Director(Base):
+    """
+    Represents a film director.
+
+    Normalized entity extracted from the legacy movies.director TEXT column.
+    One director can be linked to many movies via the MovieDirector join table,
+    enabling proper actor-director collaboration analytics.
+    """
+    __tablename__ = "directors"
+
+    id   = Column(Integer, primary_key=True, index=True)
+    name = Column(String,  unique=True, nullable=False, index=True)  # e.g. "Sukumar"
+
+    # Relationship: Director → MovieDirector → Movie
+    # Navigate via:  director.movie_director_entries[n].movie
+    movie_director_entries = relationship(
+        "MovieDirector",
+        back_populates="director",
+        cascade="all, delete-orphan",
+    )
+
+    @property
+    def movie_titles(self) -> list[str]:
+        """
+        Convenience property: returns a list of movie titles this director worked on.
+
+        Example:
+            director.movie_titles  →  ["Pushpa: The Rise", "Rangasthalam"]
+        """
+        return [entry.movie.title for entry in self.movie_director_entries]
+
+
+# ---------------------------------------------------------------------------
+# MovieDirector  (movie ↔ director join table, Sprint 2 — normalized)
+# ---------------------------------------------------------------------------
+
+class MovieDirector(Base):
+    """
+    Join table linking movies to directors (many-to-many).
+
+    Uses a composite primary key (movie_id, director_id) so the same
+    director cannot be linked to the same movie twice — the uniqueness
+    constraint is enforced at the database level without a separate index.
+
+    Future extension: add a `role` column (e.g. "Director", "Co-Director")
+    without any schema migration to existing columns.
+    """
+    __tablename__ = "movie_directors"
+
+    movie_id    = Column(Integer, ForeignKey("movies.id"),    primary_key=True, nullable=False)
+    director_id = Column(Integer, ForeignKey("directors.id"), primary_key=True, nullable=False)
+
+    # Back-references for bidirectional navigation
+    movie    = relationship("Movie",    back_populates="movie_director_entries")
+    director = relationship("Director", back_populates="movie_director_entries")
+
+
+# ---------------------------------------------------------------------------
+# ActorRegistry  (Sprint 3 — QID-based ingestion seed catalog)
+# ---------------------------------------------------------------------------
+
+class ActorRegistry(Base):
+    """
+    Catalog of South Indian actors whose filmographies are ingested from
+    Wikidata via QID-based SPARQL queries.
+
+    Why a separate table from `actors`?
+      - `actors` is populated by the ingestion pipeline and reflects what is
+        already *in* the database.
+      - `actor_registry` is the *instruction set* — it tells the pipeline
+        *which* actors to ingest and their canonical Wikidata identifiers.
+      - Keeping them separate means you can add an actor to the registry
+        before ingesting, and re-run ingestion without confusion.
+
+    wikidata_id uniqueness:
+      Each QID maps to exactly one real-world person on Wikidata, so
+      `wikidata_id` carries a UNIQUE constraint.  The `name` column is for
+      human-readable display only and is not required to be unique (though
+      in practice it will be).
+    """
+    __tablename__ = "actor_registry"
+
+    id          = Column(Integer, primary_key=True, index=True)
+    name        = Column(String,  nullable=False)                        # e.g. "Allu Arjun"
+    wikidata_id = Column(String,  unique=True, nullable=False, index=True)  # e.g. "Q352416"
+    industry    = Column(String,  nullable=False)                        # e.g. "Telugu", "Tamil"
+
+
+# ---------------------------------------------------------------------------
+# PipelineRun  (Sprint 4 — audit log for data pipeline executions)
+# ---------------------------------------------------------------------------
+
+class PipelineRun(Base):
+    """
+    Audit log entry for a single execution of a data pipeline.
+
+    One row is created when a pipeline starts (status='running') and updated
+    to 'success' or 'failed' when it finishes.  The details column stores a
+    JSON blob with per-run statistics.
+
+    Run types:
+      - "wikidata_ingestion"    — ingest_all_actors.py
+      - "wikipedia_enrichment"  — enrich_movies.py
+
+    Requires migration: backend/migrations/sprint4_pipeline_runs.sql
+    """
+    __tablename__ = "pipeline_runs"
+
+    id          = Column(Integer,  primary_key=True, index=True)
+    run_type    = Column(String(100), nullable=False)          # e.g. "wikidata_ingestion"
+    started_at  = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    finished_at = Column(DateTime(timezone=True), nullable=True)   # NULL while running
+    status      = Column(String(20), nullable=False, default="running")
+    # "running" → "success" | "failed"
+
+    details     = Column(Text, nullable=True)
+    # JSON string: e.g. '{"actors": 13, "inserted": 2, "skipped": 757}'
+
+
+# ---------------------------------------------------------------------------
+# ActorStats  (Sprint 5 — precomputed career summary per actor)
+# ---------------------------------------------------------------------------
+
+class ActorStats(Base):
+    """
+    Precomputed career statistics for one actor.
+
+    Populated (and refreshed) exclusively by build_analytics_tables.py.
+    Powers actor profile pages and career-span analytics.
+
+    Columns
+    -------
+    actor_id        : FK to actors.id (plain INT — no FK constraint for fast TRUNCATE)
+    film_count      : total distinct films the actor appears in
+    first_film_year : earliest release_year > 0 (sentinel 0 excluded)
+    last_film_year  : latest  release_year > 0 (sentinel 0 excluded)
+    avg_runtime     : average runtime in minutes (NULL if no enriched movies exist)
+
+    Requires migration: backend/migrations/sprint5_analytics_tables.sql
+    """
+    __tablename__ = "actor_stats"
+
+    actor_id        = Column(Integer, primary_key=True)
+    film_count      = Column(Integer, nullable=False, default=0)
+    first_film_year = Column(Integer, nullable=True)
+    last_film_year  = Column(Integer, nullable=True)
+    avg_runtime     = Column(Float,   nullable=True)
+
+
+# ---------------------------------------------------------------------------
+# ActorCollaboration  (Sprint 5 — co-occurrence counts between actor pairs)
+# ---------------------------------------------------------------------------
+
+class ActorCollaboration(Base):
+    """
+    How many films two actors have appeared in together.
+
+    Both directions (A→B) and (B→A) are stored with the same count so
+    dashboard queries can use a simple ``WHERE actor1_id = ?`` without OR.
+
+    Populated exclusively by build_analytics_tables.py.
+    Powers "actors who worked together" features.
+
+    Requires migration: backend/migrations/sprint5_analytics_tables.sql
+    """
+    __tablename__ = "actor_collaborations"
+
+    actor1_id           = Column(Integer, primary_key=True, nullable=False)
+    actor2_id           = Column(Integer, primary_key=True, nullable=False)
+    collaboration_count = Column(Integer, nullable=False, default=0)
+
+
+# ---------------------------------------------------------------------------
+# ActorDirectorStat  (Sprint 5 — actor × director film counts)
+# ---------------------------------------------------------------------------
+
+class ActorDirectorStat(Base):
+    """
+    How many films an actor has made with a particular director.
+
+    Sourced from the legacy movies.director TEXT column.
+    Powers "Prabhas worked with Rajamouli X times" queries.
+
+    Populated exclusively by build_analytics_tables.py.
+
+    Requires migration: backend/migrations/sprint5_analytics_tables.sql
+    """
+    __tablename__ = "actor_director_stats"
+
+    actor_id   = Column(Integer, primary_key=True, nullable=False)
+    director   = Column(String,  primary_key=True, nullable=False)
+    film_count = Column(Integer, nullable=False, default=0)
+
+
+# ---------------------------------------------------------------------------
+# ActorProductionStat  (Sprint 5 — actor × production company film counts)
+# ---------------------------------------------------------------------------
+
+class ActorProductionStat(Base):
+    """
+    How many films an actor has made under a particular production company.
+
+    Sourced from movies.production_company (populated by enrich_movies.py).
+    Powers "Vijay worked with Sun Pictures X times" queries.
+
+    Populated exclusively by build_analytics_tables.py.
+
+    Requires migration: backend/migrations/sprint5_analytics_tables.sql
+    """
+    __tablename__ = "actor_production_stats"
+
+    actor_id           = Column(Integer, primary_key=True, nullable=False)
+    production_company = Column(String,  primary_key=True, nullable=False)
+    film_count         = Column(Integer, nullable=False, default=0)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,12 +1,21 @@
 # schemas.py
 # Pydantic models define the shape of data coming IN and going OUT of the API.
 # These are separate from SQLAlchemy models (models.py = database, schemas.py = API).
+#
+# Sprint history:
+#   Sprint 1-2 : ActorBase, ActorOut, MovieBase, MovieOut, LegacyActorStats,
+#                LegacyCompareResponse
+#   Sprint 6   : ActorSearchResult, ActorProfile, ActorMovieOut,
+#                CollaboratorOut, DirectorCollabOut, ProductionOut,
+#                ActorCompareStats, CompareResponse, HealthOut
 
 from pydantic import BaseModel
 from typing import Optional, List
 
 
-# --- Actor Schemas ---
+# ===========================================================================
+# Actor Schemas
+# ===========================================================================
 
 class ActorBase(BaseModel):
     """Fields shared between actor requests and responses."""
@@ -16,14 +25,44 @@ class ActorBase(BaseModel):
 
 
 class ActorOut(ActorBase):
-    """What the API returns when listing actors."""
+    """What the API returns when listing all actors (GET /actors)."""
     id: int
 
     class Config:
         from_attributes = True  # Allows converting SQLAlchemy objects to Pydantic
 
 
-# --- Movie Schemas ---
+class ActorSearchResult(BaseModel):
+    """
+    Lightweight actor object returned by GET /actors/search?q=.
+    Intentionally minimal — the frontend needs only id + name to render
+    a search-results dropdown or list.
+    """
+    id: int
+    name: str
+
+    class Config:
+        from_attributes = True
+
+
+class ActorProfile(BaseModel):
+    """
+    Full actor profile returned by GET /actors/{actor_id}.
+    Combines the actors row with the precomputed actor_stats row so the
+    frontend never needs to fire two separate requests.
+    """
+    id: int
+    name: str
+    industry: str
+    film_count: int
+    first_film_year: Optional[int] = None   # None if all years are unknown
+    last_film_year: Optional[int] = None    # None if all years are unknown
+    avg_runtime: Optional[float] = None     # None until Wikipedia enrichment runs
+
+
+# ===========================================================================
+# Movie Schemas
+# ===========================================================================
 
 class MovieBase(BaseModel):
     """Fields shared between movie requests and responses."""
@@ -35,19 +74,116 @@ class MovieBase(BaseModel):
 
 
 class MovieOut(MovieBase):
-    """What the API returns when listing movies for an actor."""
+    """What the API returns when listing movies (legacy endpoint)."""
     id: int
 
     class Config:
         from_attributes = True
 
 
-# --- Comparison Schemas ---
-
-class ActorStats(BaseModel):
+class ActorMovieOut(BaseModel):
     """
-    Analytics summary for a single actor.
-    Returned as part of the /compare endpoint response.
+    Enriched movie row returned by GET /actors/{actor_id}/movies.
+    Uses the richer fields added by the Wikipedia enrichment pipeline.
+    Ordered by release_year DESC on the server so no client-side sorting needed.
+    """
+    title: str
+    release_year: int
+    director: Optional[str] = None
+    runtime: Optional[int] = None               # minutes
+    production_company: Optional[str] = None
+    language: Optional[str] = None
+
+    class Config:
+        from_attributes = True
+
+
+# ===========================================================================
+# Analytics / Collaboration Schemas
+# ===========================================================================
+
+class CollaboratorOut(BaseModel):
+    """
+    One row in GET /actors/{actor_id}/collaborators.
+    Sourced from the actor_collaborations precomputed table.
+    """
+    actor: str      # co-star's name
+    films: int      # number of shared films
+
+
+class DirectorCollabOut(BaseModel):
+    """
+    One row in GET /actors/{actor_id}/directors.
+    Sourced from the actor_director_stats precomputed table.
+    """
+    director: str
+    films: int
+
+
+class ProductionOut(BaseModel):
+    """
+    One row in GET /actors/{actor_id}/production.
+    Sourced from the actor_production_stats precomputed table.
+    """
+    company: str
+    films: int
+
+
+# ===========================================================================
+# Comparison Schemas  (Sprint 6 — uses analytics tables, O(1) reads)
+# ===========================================================================
+
+class ActorCompareStats(BaseModel):
+    """
+    Analytics snapshot for one actor, returned inside CompareResponse.
+    Read from the actor_stats precomputed table — no heavy joins needed.
+
+    Fields
+    ------
+    name        : canonical actor name
+    films       : total distinct films in the database
+    avg_runtime : average film runtime in minutes (null until enrichment runs)
+    first_film  : earliest known release year (null if all years are unknown)
+    last_film   : most recent known release year (null if all years are unknown)
+    """
+    name: str
+    films: int
+    avg_runtime: Optional[float] = None
+    first_film: Optional[int] = None
+    last_film: Optional[int] = None
+
+
+class CompareResponse(BaseModel):
+    """
+    Full response for GET /compare?actor1=...&actor2=...
+    Both actor slots use ActorCompareStats drawn from the actor_stats table.
+    """
+    actor1: ActorCompareStats
+    actor2: ActorCompareStats
+
+
+# ===========================================================================
+# Health Schema
+# ===========================================================================
+
+class HealthOut(BaseModel):
+    """Response shape for GET /health."""
+    status: str
+    actors: int
+    movies: int
+
+
+# ===========================================================================
+# Legacy Schemas  (kept for backward compatibility — do not remove)
+# ===========================================================================
+
+class LegacyActorStats(BaseModel):
+    """
+    Original analytics summary for a single actor (Sprint 1-2).
+    Computed on the fly from the movies table — heavier than ActorCompareStats.
+    Retained so existing tooling that calls crud.get_actor_stats() still works.
+
+    NOTE: New code should use ActorCompareStats (reads from actor_stats table).
     """
     name: str
     total_movies: int
@@ -56,7 +192,7 @@ class ActorStats(BaseModel):
     avg_box_office: Optional[float]   # Average box office in crores
 
 
-class CompareResponse(BaseModel):
-    """The full response for GET /compare?actor1=...&actor2=..."""
-    actor1: ActorStats
-    actor2: ActorStats
+class LegacyCompareResponse(BaseModel):
+    """Original compare response shape (Sprint 1-2). Kept for reference."""
+    actor1: LegacyActorStats
+    actor2: LegacyActorStats

--- a/backend/data_pipeline/__init__.py
+++ b/backend/data_pipeline/__init__.py
@@ -1,0 +1,2 @@
+# data_pipeline package
+# Sprint 2: Real Data Ingestion for South Cinema Analytics

--- a/backend/data_pipeline/build_analytics_tables.py
+++ b/backend/data_pipeline/build_analytics_tables.py
@@ -1,0 +1,311 @@
+"""
+build_analytics_tables.py
+=========================
+Rebuilds four precomputed analytics tables from the live cinema data.
+
+Why precomputed tables?
+-----------------------
+Dashboard analytics queries require expensive multi-table joins:
+
+    SELECT a.name, COUNT(*)
+    FROM   actors a
+    JOIN   "cast" c ON a.id = c.actor_id
+    JOIN   movies m ON m.id = c.movie_id
+    GROUP  BY a.name;
+
+As the dataset grows, these joins become the performance bottleneck.
+This script precomputes those aggregates once and stores them in four
+flat tables that dashboards can query with sub-millisecond O(1) lookups.
+
+Tables built
+------------
+  actor_stats
+      One row per actor: film_count, first_film_year, last_film_year,
+      avg_runtime.  Powers actor profile pages and career-span analytics.
+
+  actor_collaborations
+      One row per ordered (actor1, actor2) pair: collaboration_count.
+      Both directions (A→B and B→A) are stored so queries never need OR.
+      Powers "actors who worked together" features.
+
+  actor_director_stats
+      One row per (actor_id, director) pair: film_count.
+      Sourced from the legacy movies.director TEXT column.
+      Powers "Prabhas worked with Rajamouli X times" queries.
+
+  actor_production_stats
+      One row per (actor_id, production_company) pair: film_count.
+      Sourced from movies.production_company (populated by enrich_movies).
+      Powers "Vijay worked with Sun Pictures X times" queries.
+
+Idempotency (Task 4)
+--------------------
+Each table is TRUNCATED inside a transaction before fresh data is inserted.
+Running this script multiple times produces identical results with zero
+duplicate rows.
+
+Pipeline order (Task 6)
+-----------------------
+Run this script AFTER ingest_all_actors and (optionally) enrich_movies:
+
+    python -m data_pipeline.ingest_all_actors
+    python -m data_pipeline.enrich_movies        # optional — fills avg_runtime
+    python -m data_pipeline.build_analytics_tables
+
+Usage (Task 5)
+--------------
+    python -m data_pipeline.build_analytics_tables
+
+Environment
+-----------
+    DATABASE_URL  – PostgreSQL DSN
+                    Default: postgresql://sca:sca@postgres:5432/sca
+"""
+
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# Path bootstrap
+# ---------------------------------------------------------------------------
+_BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+from sqlalchemy import text
+
+from app.database import engine, SessionLocal
+
+# ---------------------------------------------------------------------------
+# Pretty-print helpers
+# ---------------------------------------------------------------------------
+
+_BOLD = "=" * 60
+_THIN = "-" * 60
+
+
+def _log(msg: str) -> None:
+    """Print a timestamped progress line."""
+    ts = datetime.now().strftime("%H:%M:%S")
+    print(f"  [{ts}]  {msg}")
+
+
+# ---------------------------------------------------------------------------
+# Pipeline run tracking (reuses the PipelineRun model from Sprint 4)
+# ---------------------------------------------------------------------------
+
+def _start_run() -> Optional[int]:
+    """Insert a pipeline_runs row.  Returns id or None if table missing."""
+    try:
+        from app.models import PipelineRun
+        db = SessionLocal()
+        try:
+            run = PipelineRun(
+                run_type="analytics_build",
+                started_at=datetime.now(timezone.utc),
+                status="running",
+            )
+            db.add(run)
+            db.commit()
+            db.refresh(run)
+            return run.id
+        finally:
+            db.close()
+    except Exception as exc:
+        print(f"  [pipeline_runs] Warning: could not record run start — {exc}")
+        return None
+
+
+def _finish_run(run_id: Optional[int], status: str, details: dict) -> None:
+    if run_id is None:
+        return
+    try:
+        from app.models import PipelineRun
+        db = SessionLocal()
+        try:
+            run = db.query(PipelineRun).filter(PipelineRun.id == run_id).first()
+            if run:
+                run.finished_at = datetime.now(timezone.utc)
+                run.status      = status
+                run.details     = json.dumps(details)
+                db.commit()
+        finally:
+            db.close()
+    except Exception as exc:
+        print(f"  [pipeline_runs] Warning: could not update run record — {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Individual table builders
+# All use INSERT INTO ... SELECT ... so computation happens entirely in the DB.
+# Each is wrapped in the same transaction as the TRUNCATE so a mid-run failure
+# leaves the table with its previous data (the TRUNCATE is rolled back too).
+# ---------------------------------------------------------------------------
+
+_SQL_ACTOR_STATS = text("""
+    INSERT INTO actor_stats
+        (actor_id, film_count, first_film_year, last_film_year, avg_runtime)
+    SELECT
+        a.id                                                   AS actor_id,
+        COUNT(DISTINCT c.movie_id)                             AS film_count,
+        MIN(CASE WHEN m.release_year > 0
+                 THEN m.release_year END)                      AS first_film_year,
+        MAX(CASE WHEN m.release_year > 0
+                 THEN m.release_year END)                      AS last_film_year,
+        AVG(m.runtime)                                         AS avg_runtime
+    FROM   actors a
+    JOIN   "cast" c ON a.id  = c.actor_id
+    JOIN   movies m ON m.id  = c.movie_id
+    GROUP  BY a.id
+""")
+
+# Stores BOTH (A→B) and (B→A) so queries can use a simple WHERE actor1_id = ?
+# without needing to know which id is numerically smaller.
+_SQL_ACTOR_COLLABORATIONS = text("""
+    INSERT INTO actor_collaborations
+        (actor1_id, actor2_id, collaboration_count)
+    SELECT
+        c1.actor_id                      AS actor1_id,
+        c2.actor_id                      AS actor2_id,
+        COUNT(DISTINCT c1.movie_id)      AS collaboration_count
+    FROM   "cast" c1
+    JOIN   "cast" c2
+           ON  c1.movie_id = c2.movie_id
+           AND c1.actor_id != c2.actor_id
+    GROUP  BY c1.actor_id, c2.actor_id
+""")
+
+_SQL_ACTOR_DIRECTOR_STATS = text("""
+    INSERT INTO actor_director_stats
+        (actor_id, director, film_count)
+    SELECT
+        c.actor_id                           AS actor_id,
+        m.director                           AS director,
+        COUNT(DISTINCT c.movie_id)           AS film_count
+    FROM   "cast" c
+    JOIN   movies m ON m.id = c.movie_id
+    WHERE  m.director IS NOT NULL
+      AND  m.director <> ''
+    GROUP  BY c.actor_id, m.director
+""")
+
+_SQL_ACTOR_PRODUCTION_STATS = text("""
+    INSERT INTO actor_production_stats
+        (actor_id, production_company, film_count)
+    SELECT
+        c.actor_id                           AS actor_id,
+        m.production_company                 AS production_company,
+        COUNT(DISTINCT c.movie_id)           AS film_count
+    FROM   "cast" c
+    JOIN   movies m ON m.id = c.movie_id
+    WHERE  m.production_company IS NOT NULL
+      AND  m.production_company <> ''
+    GROUP  BY c.actor_id, m.production_company
+""")
+
+
+def _build_table(
+    conn,
+    table_name: str,
+    insert_sql,
+) -> int:
+    """
+    TRUNCATE *table_name*, then run *insert_sql* inside the current transaction.
+
+    Args:
+        conn:       Active SQLAlchemy connection (inside an open transaction).
+        table_name: Table to clear before inserting.
+        insert_sql: SQLAlchemy text() INSERT INTO … SELECT statement.
+
+    Returns:
+        Number of rows inserted.
+    """
+    conn.execute(text(f"TRUNCATE {table_name}"))
+    result = conn.execute(insert_sql)
+    return result.rowcount if result.rowcount >= 0 else 0
+
+
+# ---------------------------------------------------------------------------
+# Main entry-point
+# ---------------------------------------------------------------------------
+
+def build_analytics_tables() -> int:
+    """
+    Rebuild all four analytics tables inside a single transaction.
+
+    If any step fails the transaction is rolled back, leaving every table
+    in its previous state.  No partial updates are committed.
+
+    Returns:
+        Exit code — 0 on success, 1 on error.
+    """
+    print(f"\n{_BOLD}")
+    print("  South Cinema Analytics — Build Analytics Tables")
+    print(f"{_BOLD}\n")
+
+    start_time = time.monotonic()
+    run_id     = _start_run()
+
+    stats: dict[str, int] = {}
+
+    try:
+        # Use a raw engine connection so we can control the transaction boundary
+        # explicitly and run TRUNCATE + INSERT as a single atomic unit.
+        with engine.connect() as conn:
+            with conn.begin():
+
+                # ── Table 1: actor_stats ───────────────────────────────────
+                _log("Building actor_stats ...")
+                n = _build_table(conn, "actor_stats", _SQL_ACTOR_STATS)
+                stats["actor_stats"] = n
+                _log(f"  actor_stats          → {n} row(s)")
+
+                # ── Table 2: actor_collaborations ──────────────────────────
+                _log("Building actor_collaborations ...")
+                n = _build_table(conn, "actor_collaborations", _SQL_ACTOR_COLLABORATIONS)
+                stats["actor_collaborations"] = n
+                _log(f"  actor_collaborations → {n} row(s)")
+
+                # ── Table 3: actor_director_stats ──────────────────────────
+                _log("Building actor_director_stats ...")
+                n = _build_table(conn, "actor_director_stats", _SQL_ACTOR_DIRECTOR_STATS)
+                stats["actor_director_stats"] = n
+                _log(f"  actor_director_stats → {n} row(s)")
+
+                # ── Table 4: actor_production_stats ────────────────────────
+                _log("Building actor_production_stats ...")
+                n = _build_table(conn, "actor_production_stats", _SQL_ACTOR_PRODUCTION_STATS)
+                stats["actor_production_stats"] = n
+                _log(f"  actor_production_stats → {n} row(s)")
+
+        # ── Summary ──────────────────────────────────────────────────────────
+        elapsed = time.monotonic() - start_time
+        print(f"\n{_THIN}")
+        print("  Analytics tables built successfully ✓")
+        print(f"{_THIN}")
+        for tbl, rows in stats.items():
+            print(f"    {tbl:<30} {rows:>6} row(s)")
+        print(f"  Elapsed : {elapsed:.1f} s")
+        print(f"{_BOLD}\n")
+
+        _finish_run(run_id, "success", {**stats, "elapsed_s": round(elapsed, 1)})
+        return 0
+
+    except Exception as exc:
+        elapsed = time.monotonic() - start_time
+        print(f"\n  ✗ Build failed: {exc}")
+        print(f"    (transaction rolled back — all analytics tables unchanged)\n")
+        _finish_run(run_id, "failed", {"error": str(exc), "elapsed_s": round(elapsed, 1)})
+        return 1
+
+
+# ---------------------------------------------------------------------------
+# CLI entry-point (Task 5)
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    sys.exit(build_analytics_tables())

--- a/backend/data_pipeline/enrich_movies.py
+++ b/backend/data_pipeline/enrich_movies.py
@@ -1,0 +1,554 @@
+"""
+enrich_movies.py
+================
+Enriches existing movie records in the database with metadata from Wikipedia.
+
+For every movie that has runtime = NULL, the script:
+  1. Calls fetch_movie_metadata(title) to retrieve runtime, production_company,
+     and language from the Wikipedia film infobox.
+  2. Updates *only* the columns that are currently NULL (never overwrites
+     existing data).
+  3. Commits the update for that movie immediately so progress is preserved
+     even if the script is interrupted mid-run.
+
+Sprint 4 additions
+------------------
+  Parallel workers (Task 5):
+    Uses concurrent.futures.ThreadPoolExecutor to process multiple movies at
+    the same time.  Each worker creates its own DB session to avoid sharing
+    state across threads.  Set --workers N to control parallelism (default 1,
+    meaning sequential — the Sprint 2 behaviour is preserved by default).
+
+    Wikipedia rate-limiting note: each worker sleeps REQUEST_DELAY (1 s) before
+    every live HTTP call.  With 5 workers running concurrently the effective
+    request rate is ~5 req/s toward Wikipedia.  Wikipedia's bot policy allows
+    up to 200 req/min (~3.3 req/s) for registered bots; anonymous scripts
+    should stay lower.  Keep --workers ≤ 3 for production runs; use --workers 5
+    only for one-off backfill operations where you have pre-warmed the cache.
+
+  Pipeline run tracking (Task 6):
+    Creates a pipeline_runs row at the start of every run and updates it with
+    final stats when the run finishes.  Requires the sprint4_pipeline_runs.sql
+    migration to have been applied first.  If the table does not exist the
+    script still runs; the tracking step is skipped with a warning.
+
+The script is intentionally conservative:
+  - It does NOT touch movies.director or any other column.
+  - It does NOT modify existing (non-NULL) values.
+  - It does NOT delete or recreate any rows.
+
+Usage:
+    # From the backend/ directory (preferred):
+    python -m data_pipeline.enrich_movies
+    python -m data_pipeline.enrich_movies --dry-run
+    python -m data_pipeline.enrich_movies --batch-size 50 --workers 3
+    python -m data_pipeline.enrich_movies --batch-size 5 --workers 5 --dry-run
+
+    # Or directly:
+    python data_pipeline/enrich_movies.py --workers 3
+
+Flags:
+    --dry-run        Print what would be updated without writing to the DB.
+    --batch-size N   Process at most N movies per run (default: unlimited).
+    --industry X     Filter to movies with industry = X (e.g. "Telugu").
+    --workers N      Number of parallel Wikipedia fetch workers (default: 1).
+
+Environment:
+    DATABASE_URL  – PostgreSQL DSN
+                    Default: postgresql://sca:sca@postgres:5432/sca
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# Path bootstrap — same pattern as ingest_actor.py
+# ---------------------------------------------------------------------------
+_BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+from sqlalchemy.orm import Session
+
+from app.database import SessionLocal
+from app.models import Movie
+from data_pipeline.wikipedia_client import fetch_movie_metadata
+
+
+# ---------------------------------------------------------------------------
+# Pretty-print helpers
+# ---------------------------------------------------------------------------
+
+_SEP_THIN = "-" * 52
+_SEP_BOLD = "=" * 52
+
+
+def _print_header(total: int, dry_run: bool, workers: int) -> None:
+    mode = "  [DRY RUN — no DB writes]" if dry_run else ""
+    print(f"\n{_SEP_BOLD}")
+    print(f"  Wikipedia Enrichment{mode}")
+    print(f"  Movies to process : {total}")
+    if workers > 1:
+        print(f"  Parallel workers  : {workers}")
+    print(f"{_SEP_BOLD}\n")
+
+
+def _print_movie_result(
+    index: int,
+    total: int,
+    result: dict,
+    dry_run: bool,
+) -> None:
+    """Print a single worker result in the standard format."""
+    title = result["title"]
+    year  = result["year"]
+    meta  = result.get("meta", {})
+    updates = result.get("updates", {})
+    error   = result.get("error")
+    changed = result.get("changed", False)
+
+    print(f"[{index}/{total}] Processing: {title} ({year})")
+    print(_SEP_THIN)
+
+    if error:
+        print(f"  ✗ Error: {error}")
+        print()
+        return
+
+    # Print per-field results.
+    runtime_val = meta.get("runtime")
+    company_val = meta.get("production_company")
+    language_val = meta.get("language")
+
+    _print_field("Runtime",            runtime_val,  "runtime"            in updates, dry_run)
+    _print_field("Production company", company_val,  "production_company" in updates, dry_run)
+    _print_field("Language",           language_val, "language"           in updates, dry_run)
+
+    if changed:
+        action = "Would update" if dry_run else "Saved"
+        print(f"  → {action} successfully.")
+    else:
+        print("  → No new data found, skipped.")
+    print()
+
+
+def _print_field(label: str, value, found: bool, dry_run: bool) -> None:
+    """Print a single enriched field with consistent formatting."""
+    if found:
+        status = "  (would set)" if dry_run else "  ✓"
+    else:
+        status = "  (not found)"
+
+    padded  = f"  {label:<22}"
+    val_str = str(value) if value is not None else "—"
+    print(f"{padded}: {val_str}{status}")
+
+
+# ---------------------------------------------------------------------------
+# Pipeline run tracking helpers (Task 6)
+# ---------------------------------------------------------------------------
+
+def _start_pipeline_run(run_type: str) -> Optional[int]:
+    """
+    Insert a new pipeline_runs row with status='running'.
+
+    Returns the new row's id, or None if the table doesn't exist yet
+    (migration not applied).
+    """
+    try:
+        from app.models import PipelineRun  # imported here to avoid circular issues
+        db: Session = SessionLocal()
+        try:
+            run = PipelineRun(
+                run_type=run_type,
+                started_at=datetime.now(timezone.utc),
+                status="running",
+            )
+            db.add(run)
+            db.commit()
+            db.refresh(run)
+            return run.id
+        finally:
+            db.close()
+    except Exception as exc:
+        print(f"  [pipeline_runs] Warning: could not record run start — {exc}")
+        return None
+
+
+def _finish_pipeline_run(run_id: Optional[int], status: str, details: dict) -> None:
+    """Update an existing pipeline_runs row with the final status and stats."""
+    if run_id is None:
+        return
+    try:
+        from app.models import PipelineRun
+        db: Session = SessionLocal()
+        try:
+            run = db.query(PipelineRun).filter(PipelineRun.id == run_id).first()
+            if run:
+                run.finished_at = datetime.now(timezone.utc)
+                run.status      = status
+                run.details     = json.dumps(details)
+                db.commit()
+        finally:
+            db.close()
+    except Exception as exc:
+        print(f"  [pipeline_runs] Warning: could not update run record — {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Worker function (Task 5 — parallel enrichment)
+# ---------------------------------------------------------------------------
+
+def _enrich_movie_worker(movie_data: dict, dry_run: bool) -> dict:
+    """
+    Thread worker: fetch Wikipedia metadata for one movie and optionally
+    write changes to the DB.
+
+    Each worker creates its own SQLAlchemy session so threads never share
+    database connections.
+
+    Args:
+        movie_data: Plain dict snapshot of the movie row with keys:
+                    id, title, year, runtime, production_company, language.
+        dry_run:    If True, compute changes but do not commit to DB.
+
+    Returns:
+        Result dict::
+
+            {
+                "id":       int,
+                "title":    str,
+                "year":     int,
+                "changed":  bool,
+                "error":    str | None,
+                "meta":     {"runtime": …, "production_company": …, "language": …},
+                "updates":  {"runtime": …},   # only keys that will change
+            }
+    """
+    result: dict = {
+        "id":      movie_data["id"],
+        "title":   movie_data["title"],
+        "year":    movie_data["year"],
+        "changed": False,
+        "error":   None,
+        "meta":    {},
+        "updates": {},
+    }
+
+    try:
+        meta = fetch_movie_metadata(movie_data["title"])
+    except Exception as exc:
+        result["error"] = str(exc)
+        return result
+
+    result["meta"] = meta
+
+    runtime_val  = meta.get("runtime")
+    company_val  = meta.get("production_company")
+    language_val = meta.get("language")
+
+    # Build the dict of fields that would change (never overwrite non-NULL).
+    updates: dict = {}
+    if runtime_val  is not None and movie_data["runtime"]            is None:
+        updates["runtime"]            = runtime_val
+    if company_val  and not movie_data["production_company"]:
+        updates["production_company"] = company_val
+    if language_val and not movie_data["language"]:
+        updates["language"]           = language_val
+
+    result["updates"] = updates
+    result["changed"] = bool(updates)
+
+    if updates and not dry_run:
+        # Each worker opens its own session — never share across threads.
+        db: Session = SessionLocal()
+        try:
+            movie = db.query(Movie).filter(Movie.id == movie_data["id"]).first()
+            if movie:
+                for col, val in updates.items():
+                    setattr(movie, col, val)
+                db.commit()
+            else:
+                result["error"]   = f"Movie id={movie_data['id']} not found in DB"
+                result["changed"] = False
+        except Exception as exc:
+            db.rollback()
+            result["error"]   = str(exc)
+            result["changed"] = False
+        finally:
+            db.close()
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Sequential fallback (workers=1) — keeps original behaviour
+# ---------------------------------------------------------------------------
+
+def _enrich_one_movie(db: Session, movie: Movie, dry_run: bool) -> dict:
+    """
+    Fetch Wikipedia metadata for *movie* and apply missing fields.
+    Used in single-worker (sequential) mode only.
+
+    Args:
+        db:      Active SQLAlchemy session.
+        movie:   Movie ORM instance to enrich.
+        dry_run: If True, compute and log changes but do not commit.
+
+    Returns:
+        Worker-compatible result dict.
+    """
+    movie_data = {
+        "id":                movie.id,
+        "title":             movie.title,
+        "year":              movie.release_year,
+        "runtime":           movie.runtime,
+        "production_company": movie.production_company,
+        "language":          movie.language,
+    }
+
+    # Use the worker function logic but pass dry_run=True to skip its DB write;
+    # we commit via the shared session below instead.
+    result = _enrich_movie_worker(movie_data, dry_run=True)
+
+    if result["updates"] and not dry_run:
+        for col, val in result["updates"].items():
+            setattr(movie, col, val)
+        try:
+            db.commit()
+            result["changed"] = True
+        except Exception as exc:
+            db.rollback()
+            result["error"]   = str(exc)
+            result["changed"] = False
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Main enrichment driver
+# ---------------------------------------------------------------------------
+
+def enrich_movies(
+    batch_size: int  = 0,
+    dry_run:    bool = False,
+    industry:   str  = "",
+    workers:    int  = 1,
+) -> None:
+    """
+    Query the database for movies with NULL runtime and enrich them
+    using Wikipedia metadata.
+
+    With workers=1 (default) the behaviour is identical to Sprint 2:
+    movies are processed one at a time in a single shared session.
+
+    With workers>1 a ThreadPoolExecutor processes multiple movies in
+    parallel.  Each worker manages its own DB session.
+
+    Args:
+        batch_size: Maximum number of movies to process.  0 = no limit.
+        dry_run:    If True, log what would change without writing to DB.
+        industry:   Optional filter, e.g. "Telugu".  Empty = all industries.
+        workers:    Number of parallel Wikipedia fetch threads (default: 1).
+    """
+    start_time = time.monotonic()
+
+    # ── Pipeline run tracking ─────────────────────────────────────────────
+    run_id = _start_pipeline_run("wikipedia_enrichment")
+
+    # ── Load movies to enrich ─────────────────────────────────────────────
+    db: Session = SessionLocal()
+    try:
+        q = db.query(Movie).filter(Movie.runtime.is_(None))
+
+        if industry:
+            q = q.filter(Movie.industry == industry)
+
+        # Prefer recently released movies (more likely to have Wikipedia pages).
+        q = q.order_by(Movie.release_year.desc(), Movie.title)
+
+        if batch_size > 0:
+            q = q.limit(batch_size)
+
+        movies = q.all()
+
+        if not movies:
+            print("\nNothing to enrich — all movies already have a runtime value.\n")
+            _finish_pipeline_run(run_id, "success", {"processed": 0, "updated": 0, "skipped": 0})
+            return
+
+        # Snapshot plain dicts so ORM objects are not shared across threads.
+        movie_snapshots: list[dict] = [
+            {
+                "id":                 m.id,
+                "title":              m.title,
+                "year":               m.release_year,
+                "runtime":            m.runtime,
+                "production_company": m.production_company,
+                "language":           m.language,
+            }
+            for m in movies
+        ]
+
+        # Hold the shared session for sequential mode; close before parallel.
+        if workers > 1:
+            db.close()
+            db = None  # type: ignore[assignment]
+
+    except Exception as exc:
+        db.rollback()
+        db.close()
+        _finish_pipeline_run(run_id, "failed", {"error": str(exc)})
+        print(f"\nFATAL: {exc}\n")
+        raise
+
+    _print_header(total=len(movie_snapshots), dry_run=dry_run, workers=workers)
+
+    updated = 0
+    skipped = 0
+    errored = 0
+    results_ordered: list[dict] = []
+
+    # ── PARALLEL mode ─────────────────────────────────────────────────────
+    if workers > 1:
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            future_to_snap = {
+                executor.submit(_enrich_movie_worker, snap, dry_run): snap
+                for snap in movie_snapshots
+            }
+
+            # Collect results in completion order; print them sequentially.
+            completed_results: dict[int, dict] = {}
+            for future in as_completed(future_to_snap):
+                result = future.result()
+                completed_results[result["id"]] = result
+
+        # Re-sort to original query order for consistent output.
+        for snap in movie_snapshots:
+            results_ordered.append(completed_results[snap["id"]])
+
+    # ── SEQUENTIAL mode (workers=1) ───────────────────────────────────────
+    else:
+        if db is None:
+            db = SessionLocal()
+
+        for snap in movie_snapshots:
+            movie_orm = db.query(Movie).filter(Movie.id == snap["id"]).first()
+            if movie_orm is None:
+                results_ordered.append({
+                    "id": snap["id"], "title": snap["title"], "year": snap["year"],
+                    "changed": False, "error": "not found in DB", "meta": {}, "updates": {},
+                })
+                continue
+
+            try:
+                result = _enrich_one_movie(db, movie_orm, dry_run)
+            except Exception as exc:
+                db.rollback()
+                result = {
+                    "id": snap["id"], "title": snap["title"], "year": snap["year"],
+                    "changed": False, "error": str(exc), "meta": {}, "updates": {},
+                }
+            results_ordered.append(result)
+
+        db.close()
+
+    # ── Print results and tally ───────────────────────────────────────────
+    for i, result in enumerate(results_ordered, start=1):
+        _print_movie_result(i, len(results_ordered), result, dry_run)
+
+        if result.get("error"):
+            errored += 1
+        elif result.get("changed"):
+            updated += 1
+        else:
+            skipped += 1
+
+    elapsed = time.monotonic() - start_time
+
+    # ── Final summary ─────────────────────────────────────────────────────
+    print(_SEP_BOLD)
+    mode = "DRY RUN — " if dry_run else ""
+    print(f"  {mode}Enrichment complete")
+    print(f"  Updated  : {updated}")
+    print(f"  Skipped  : {skipped}  (no new data found on Wikipedia)")
+    if errored:
+        print(f"  Errors   : {errored}  (check output above)")
+    print(f"  Total    : {len(results_ordered)}")
+    print(f"  Elapsed  : {elapsed:.1f} s")
+    print(f"{_SEP_BOLD}\n")
+
+    # ── Update pipeline_runs record ───────────────────────────────────────
+    final_status = "failed" if errored and (updated + skipped) == 0 else "success"
+    _finish_pipeline_run(run_id, final_status, {
+        "processed": len(results_ordered),
+        "updated":   updated,
+        "skipped":   skipped,
+        "errors":    errored,
+        "elapsed_s": round(elapsed, 1),
+        "workers":   workers,
+        "dry_run":   dry_run,
+    })
+
+
+# ---------------------------------------------------------------------------
+# CLI entry-point
+# ---------------------------------------------------------------------------
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="enrich_movies",
+        description=(
+            "Enrich movies.runtime / production_company / language "
+            "from Wikipedia infoboxes."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Print what would be updated without writing to the database.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=0,
+        metavar="N",
+        help="Process at most N movies (default: 0 = no limit).",
+    )
+    parser.add_argument(
+        "--industry",
+        type=str,
+        default="",
+        metavar="INDUSTRY",
+        help='Filter to a specific industry, e.g. "Telugu" or "Tamil".',
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=1,
+        metavar="N",
+        help=(
+            "Number of parallel Wikipedia fetch workers (default: 1). "
+            "With workers=1 the script runs sequentially (Sprint 2 behaviour). "
+            "Recommended: ≤ 3 for production; use 5 only for one-off backfills "
+            "with a pre-warmed cache."
+        ),
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    enrich_movies(
+        batch_size=args.batch_size,
+        dry_run=args.dry_run,
+        industry=args.industry,
+        workers=max(1, args.workers),
+    )

--- a/backend/data_pipeline/ingest_actor.py
+++ b/backend/data_pipeline/ingest_actor.py
@@ -1,0 +1,400 @@
+"""
+ingest_actor.py
+===============
+CLI script that runs the full data ingestion pipeline for a single actor.
+
+Sprint 3 change — QID-based lookups
+-------------------------------------
+The Wikidata query now resolves the actor via their canonical QID rather than
+by name, eliminating ambiguity for common names such as "Vijay".
+
+``ingest_actor()`` now accepts a ``wikidata_id`` parameter.  When called from
+the CLI without a QID, the script looks it up automatically from the
+``actor_registry`` table so existing command-line usage still works:
+
+    python -m data_pipeline.ingest_actor "Allu Arjun"
+    # ^ looks up Q352416 from actor_registry automatically
+
+Providing the QID explicitly is faster (skips the DB lookup) and works even
+for actors not yet in the registry:
+
+    python -m data_pipeline.ingest_actor "Allu Arjun" Telugu Q352416
+
+Pipeline steps (unchanged from Sprint 2):
+  1. Query Wikidata for the actor's filmography (now via QID).
+  2. Upsert the actor record into `actors`.
+  3. Upsert each movie record into `movies`.
+  4. Upsert each director into `directors` + `movie_directors` join table.
+  5. Create cast relationships in `cast`.
+
+Every step remains idempotent.
+
+Usage:
+    python -m data_pipeline.ingest_actor "Allu Arjun"
+    python -m data_pipeline.ingest_actor "Allu Arjun" Telugu Q352416
+    python -m data_pipeline.ingest_actor "Vijay"      Tamil  Q536725
+
+Environment:
+    DATABASE_URL – PostgreSQL DSN (default: postgresql://sca:sca@postgres:5432/sca)
+"""
+
+import os
+import sys
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# Path bootstrap — makes `app` importable when run directly.
+# ---------------------------------------------------------------------------
+_BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+from sqlalchemy.orm import Session
+
+from app.database import SessionLocal
+from app.models import Actor, ActorRegistry, Cast, Director, Movie, MovieDirector
+from data_pipeline.wikidata_client import fetch_actor_filmography
+
+
+# ---------------------------------------------------------------------------
+# Upsert helpers
+# All helpers share the same contract:
+#   • Operate within the caller's session / transaction.
+#   • Never commit — the pipeline commits once at the very end.
+#   • Flush after INSERT so the PK is available immediately.
+# ---------------------------------------------------------------------------
+
+def _get_or_create_actor(db: Session, name: str, industry: str) -> Actor:
+    """
+    Upsert an actor row.
+
+    Lookup key: actors.name  (UNIQUE constraint in DB)
+
+    Args:
+        db:       Active SQLAlchemy session.
+        name:     Actor's full English name, e.g. "Allu Arjun".
+        industry: Film industry label, e.g. "Telugu".
+
+    Returns:
+        Actor ORM instance with populated .id.
+    """
+    actor = db.query(Actor).filter(Actor.name == name).first()
+    if actor:
+        print(f"  [~] Actor already exists : {name!r} (id={actor.id})")
+        return actor
+
+    actor = Actor(name=name, industry=industry)
+    db.add(actor)
+    db.flush()
+    print(f"  [+] Created actor        : {name!r} (id={actor.id})")
+    return actor
+
+
+def _get_or_create_movie(
+    db: Session,
+    title: str,
+    year: Optional[int],
+    director: Optional[str],
+    industry: str,
+) -> tuple["Movie", bool]:
+    """
+    Upsert a movie row.
+
+    Lookup key: (movies.title, movies.release_year).
+    When *year* is unknown, release_year is stored as 0 (sentinel) and
+    matching falls back to title-only.
+
+    The legacy ``movies.director`` TEXT column is kept in sync for backward
+    compatibility.  New analytics code should use the movie_directors table.
+
+    Args:
+        db:       Active SQLAlchemy session.
+        title:    Film title from Wikidata.
+        year:     Release year, or None.
+        director: Director name for the legacy TEXT column, or None.
+        industry: Industry label inherited from the ingested actor.
+
+    Returns:
+        Tuple of (Movie ORM instance, is_new: bool).
+        is_new is True if the row was inserted, False if it already existed.
+    """
+    release_year = year if year is not None else 0
+
+    q = db.query(Movie).filter(Movie.title == title)
+    if year is not None:
+        q = q.filter(Movie.release_year == year)
+    movie = q.first()
+
+    if movie:
+        # Back-fill the legacy director text if the existing row is missing it.
+        if director and not movie.director:
+            movie.director = director
+        print(f"    [~] Movie already exists : {title!r} ({release_year})")
+        return movie, False
+
+    movie = Movie(
+        title=title,
+        release_year=release_year,
+        industry=industry,
+        director=director,   # legacy TEXT — kept for backward compat
+    )
+    db.add(movie)
+    db.flush()
+    print(f"    [+] Created movie        : {title!r} ({release_year})")
+    return movie, True
+
+
+def _get_or_create_director(db: Session, name: str) -> Director:
+    """
+    Upsert a director row in the normalized `directors` table.
+
+    Lookup key: directors.name  (UNIQUE constraint in DB)
+    """
+    director = db.query(Director).filter(Director.name == name).first()
+    if director:
+        return director   # silent — director rows are high-volume noise otherwise
+
+    director = Director(name=name)
+    db.add(director)
+    db.flush()
+    print(f"      [+] Created director     : {name!r} (id={director.id})")
+    return director
+
+
+def _get_or_create_movie_director(
+    db: Session, movie_id: int, director_id: int
+) -> MovieDirector:
+    """
+    Upsert a row in the `movie_directors` join table.
+
+    The composite PK (movie_id, director_id) guarantees DB-level uniqueness.
+    We pre-check to avoid an IntegrityError on duplicate insert.
+    """
+    link = (
+        db.query(MovieDirector)
+        .filter(
+            MovieDirector.movie_id    == movie_id,
+            MovieDirector.director_id == director_id,
+        )
+        .first()
+    )
+    if link:
+        return link   # already linked — idempotent
+
+    link = MovieDirector(movie_id=movie_id, director_id=director_id)
+    db.add(link)
+    print(f"      [+] Linked movie {movie_id} ↔ director {director_id}")
+    return link
+
+
+def _get_or_create_cast(db: Session, actor_id: int, movie_id: int) -> Cast:
+    """
+    Upsert a row in the `cast` join table.
+    """
+    cast = (
+        db.query(Cast)
+        .filter(Cast.actor_id == actor_id, Cast.movie_id == movie_id)
+        .first()
+    )
+    if cast:
+        return cast   # already linked — idempotent
+
+    cast = Cast(actor_id=actor_id, movie_id=movie_id, role_type="Lead")
+    db.add(cast)
+    print(f"      [+] Linked actor {actor_id} ↔ movie  {movie_id}")
+    return cast
+
+
+def _resolve_qid_from_registry(db: Session, actor_name: str) -> Optional[str]:
+    """
+    Look up an actor's Wikidata QID from the actor_registry table by name.
+
+    Used as a convenience fallback when the CLI caller does not supply a QID
+    explicitly — so ``python -m data_pipeline.ingest_actor "Allu Arjun"``
+    still works as long as the actor exists in actor_registry.
+
+    Args:
+        db:         Active SQLAlchemy session.
+        actor_name: Display name to search, e.g. "Allu Arjun".
+
+    Returns:
+        QID string (e.g. "Q352416") or None if not found in registry.
+    """
+    entry = (
+        db.query(ActorRegistry)
+        .filter(ActorRegistry.name == actor_name)
+        .first()
+    )
+    return entry.wikidata_id if entry else None
+
+
+# ---------------------------------------------------------------------------
+# Main pipeline
+# ---------------------------------------------------------------------------
+
+def ingest_actor(
+    actor_name:  str,
+    industry:    str = "Telugu",
+    wikidata_id: str = "",
+) -> dict:
+    """
+    Run the full five-step ingestion pipeline for one actor.
+
+    All DB writes (steps 2-5) happen in a single transaction.  The transaction
+    is rolled back cleanly on any error.
+
+    Args:
+        actor_name:  Full English name of the actor, e.g. "Allu Arjun".
+        industry:    Film industry label for new records (default "Telugu").
+        wikidata_id: Wikidata QID, e.g. "Q352416".  If empty, the QID is
+                     looked up from the actor_registry table by name.  An
+                     error is raised if the QID cannot be found either way.
+
+    Returns:
+        Stats dict:
+            {
+                "actor":    "Allu Arjun",
+                "qid":      "Q352416",
+                "total":    24,   # films returned by Wikidata
+                "inserted": 2,    # new movie rows created
+                "skipped":  22,   # movie rows that already existed
+            }
+
+    Raises:
+        ValueError:  if no QID is provided and the actor is not in the registry.
+        Exception:   re-raises any DB or network error after rolling back.
+    """
+    sep = "=" * 62
+    print(f"\n{sep}")
+    print(f"  Ingesting : {actor_name}  [{industry}]")
+    print(sep)
+
+    # ------------------------------------------------------------------
+    # Step 0 — Resolve QID (new in Sprint 3)
+    # ------------------------------------------------------------------
+    db_for_lookup: Session = SessionLocal()
+    try:
+        qid = wikidata_id.strip() if wikidata_id.strip() else None
+        if not qid:
+            print("\n[0/5] Resolving QID from actor_registry...")
+            qid = _resolve_qid_from_registry(db_for_lookup, actor_name)
+            if qid:
+                print(f"      Found QID : {qid}")
+            else:
+                raise ValueError(
+                    f"No Wikidata QID found for {actor_name!r}.\n"
+                    f"  Either:\n"
+                    f"    1. Add the actor to actor_registry, or\n"
+                    f"    2. Pass the QID explicitly:\n"
+                    f"       python -m data_pipeline.ingest_actor "
+                    f'"{actor_name}" {industry} Q<ID>'
+                )
+    finally:
+        db_for_lookup.close()
+
+    # ------------------------------------------------------------------
+    # Step 1 — Fetch filmography from Wikidata via QID
+    # ------------------------------------------------------------------
+    print(f"\n[1/5] Querying Wikidata for {actor_name} ({qid})...")
+    data   = fetch_actor_filmography(wikidata_id=qid, actor_name=actor_name)
+    movies = data.get("movies", [])
+
+    if not movies:
+        print("      ⚠  No films found on Wikidata.")
+        print(f"         Verify QID at: https://www.wikidata.org/wiki/{qid}")
+        return {"actor": actor_name, "qid": qid, "total": 0, "inserted": 0, "skipped": 0}
+
+    directors_found = sum(1 for m in movies if m.get("director"))
+    print(f"      Found {len(movies)} film(s), "
+          f"{directors_found} with a known director.")
+
+    # ------------------------------------------------------------------
+    # Steps 2-5 — Write to PostgreSQL inside one transaction
+    # ------------------------------------------------------------------
+    inserted = 0
+    skipped  = 0
+
+    db: Session = SessionLocal()
+    try:
+        # Step 2 — Upsert actor
+        print("\n[2/5] Upserting actor...")
+        actor = _get_or_create_actor(db, actor_name, industry)
+
+        # Steps 3-5 — Per-film loop
+        print("\n[3/5] Upserting movies...")
+        print("[4/5] Upserting directors + movie_directors links...")
+        print("[5/5] Creating cast relationships...")
+        print()
+
+        for movie_data in movies:
+            title    = movie_data["title"]
+            year     = movie_data.get("year")
+            dir_name = movie_data.get("director")
+
+            # Step 3: upsert movie (also keeps legacy director TEXT in sync).
+            movie, is_new = _get_or_create_movie(
+                db,
+                title=title,
+                year=year,
+                director=dir_name,
+                industry=industry,
+            )
+            if is_new:
+                inserted += 1
+            else:
+                skipped += 1
+
+            # Step 4: upsert director + join-table row (if known).
+            if dir_name:
+                director_obj = _get_or_create_director(db, dir_name)
+                _get_or_create_movie_director(db, movie.id, director_obj.id)
+
+            # Step 5: upsert cast link (actor ↔ movie).
+            _get_or_create_cast(db, actor.id, movie.id)
+
+        db.commit()
+
+        print(f"\n  ✓ Done! {actor_name} ({qid})")
+        print(f"    Total films  : {len(movies)}")
+        print(f"    Inserted     : {inserted} new movie(s)")
+        print(f"    Skipped      : {skipped} already in DB")
+
+    except Exception as exc:
+        db.rollback()
+        print(f"\n  ✗ Ingestion failed — transaction rolled back.")
+        print(f"    Error: {exc}")
+        raise
+
+    finally:
+        db.close()
+
+    return {
+        "actor":    actor_name,
+        "qid":      qid,
+        "total":    len(movies),
+        "inserted": inserted,
+        "skipped":  skipped,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI entry-point
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage  : python -m data_pipeline.ingest_actor <actor_name> [industry] [QID]")
+        print()
+        print("Examples:")
+        print('  python -m data_pipeline.ingest_actor "Allu Arjun"')
+        print('  python -m data_pipeline.ingest_actor "Allu Arjun" Telugu Q352416')
+        print('  python -m data_pipeline.ingest_actor "Vijay"      Tamil  Q536725')
+        print()
+        print("If QID is omitted, it is looked up from the actor_registry table.")
+        sys.exit(1)
+
+    _name     = sys.argv[1]
+    _industry = sys.argv[2] if len(sys.argv) > 2 else "Telugu"
+    _qid      = sys.argv[3] if len(sys.argv) > 3 else ""
+
+    ingest_actor(_name, _industry, _qid)

--- a/backend/data_pipeline/ingest_all_actors.py
+++ b/backend/data_pipeline/ingest_all_actors.py
@@ -1,0 +1,576 @@
+"""
+ingest_all_actors.py
+====================
+Batch ingestion script: reads every actor from the ``actor_registry`` table
+and ingests their full Wikidata filmographies into the database using batched
+SPARQL queries.
+
+Why batching?
+-------------
+The Sprint 3 version issued one Wikidata SPARQL request per actor — 13 actors
+meant 13 sequential HTTP calls and 13+ seconds of rate-limit delay.
+
+This version groups actors into batches of up to BATCH_SIZE (default 20) and
+issues ONE SPARQL query per batch via a ``VALUES`` clause, collapsing 13 calls
+into a single round-trip.  Wall-clock time drops from ~15 s to ~2 s for all
+13 actors.
+
+How it works
+------------
+1. Load all ActorRegistry rows from the DB (optionally filtered/limited).
+2. Split them into batches of ``batch_size`` actors.
+3. For each batch:
+   a. Call ``fetch_filmography_batch(qids)`` — one SPARQL request for all actors.
+   b. Group the flat result list by ``actor_qid``.
+   c. For each actor in the batch, write movies/directors/cast to the DB,
+      committing once per actor so a single failure never rolls back others.
+4. Sleep 1 second between batches (polite rate limiting).
+5. Print a cumulative summary at the end.
+
+``ingest_actor.py`` remains available for one-off / manual ingestion of a
+single actor.  Its private upsert helpers are imported and reused here so
+the DB logic lives in exactly one place.
+
+Sprint 4 addition — Pipeline run tracking (Task 6)
+---------------------------------------------------
+Creates a pipeline_runs row at the start of every run and updates it with
+the final actor/film statistics when the run finishes.  Requires the
+sprint4_pipeline_runs.sql migration.  If the table does not exist the
+script continues normally and the tracking step is silently skipped.
+
+Flags
+-----
+    --batch-size N       Actors per SPARQL query (default: 20, max recommended).
+    --industry INDUSTRY  Process only actors from a specific industry.
+    --dry-run            Perform Wikidata queries but skip all DB writes.
+    --limit N            Process at most N actors (useful for testing).
+
+Usage
+-----
+    # From the backend/ directory:
+    python -m data_pipeline.ingest_all_actors
+    python -m data_pipeline.ingest_all_actors --industry Telugu
+    python -m data_pipeline.ingest_all_actors --limit 3 --dry-run
+    python -m data_pipeline.ingest_all_actors --batch-size 5
+
+Environment
+-----------
+    DATABASE_URL  – PostgreSQL DSN (default: postgresql://sca:sca@postgres:5432/sca)
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# Path bootstrap
+# ---------------------------------------------------------------------------
+_BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+from sqlalchemy.orm import Session
+
+from app.database import SessionLocal
+from app.models import ActorRegistry
+from data_pipeline.wikidata_batch_client import BATCH_SIZE, fetch_filmography_batch
+
+
+# ---------------------------------------------------------------------------
+# Pipeline run tracking helpers (Task 6)
+# ---------------------------------------------------------------------------
+
+def _start_pipeline_run(run_type: str) -> Optional[int]:
+    """
+    Insert a pipeline_runs row with status='running'.
+
+    Returns the new row id, or None if the table does not exist yet
+    (migration not applied — script continues without tracking).
+    """
+    try:
+        from app.models import PipelineRun
+        db: Session = SessionLocal()
+        try:
+            run = PipelineRun(
+                run_type=run_type,
+                started_at=datetime.now(timezone.utc),
+                status="running",
+            )
+            db.add(run)
+            db.commit()
+            db.refresh(run)
+            return run.id
+        finally:
+            db.close()
+    except Exception as exc:
+        print(f"  [pipeline_runs] Warning: could not record run start — {exc}")
+        return None
+
+
+def _finish_pipeline_run(run_id: Optional[int], status: str, details: dict) -> None:
+    """Update an existing pipeline_runs row with the final status and stats."""
+    if run_id is None:
+        return
+    try:
+        from app.models import PipelineRun
+        db: Session = SessionLocal()
+        try:
+            run = db.query(PipelineRun).filter(PipelineRun.id == run_id).first()
+            if run:
+                run.finished_at = datetime.now(timezone.utc)
+                run.status      = status
+                run.details     = json.dumps(details)
+                db.commit()
+        finally:
+            db.close()
+    except Exception as exc:
+        print(f"  [pipeline_runs] Warning: could not update run record — {exc}")
+
+# Reuse the private upsert helpers from ingest_actor so DB logic stays DRY.
+from data_pipeline.ingest_actor import (
+    _get_or_create_actor,
+    _get_or_create_cast,
+    _get_or_create_director,
+    _get_or_create_movie,
+    _get_or_create_movie_director,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pretty-print helpers
+# ---------------------------------------------------------------------------
+
+_BOLD = "=" * 64
+_THIN = "-" * 64
+
+
+def _print_run_header(
+    total: int,
+    batch_size: int,
+    industry_filter: str,
+    dry_run: bool,
+) -> None:
+    mode = "  *** DRY RUN — no DB writes ***" if dry_run else ""
+    n_batches = (total + batch_size - 1) // batch_size
+    print(f"\n{_BOLD}")
+    print(f"  South Cinema Analytics — Batched Wikidata Ingestion{mode}")
+    print(f"  Actors to process : {total}")
+    print(f"  Batch size        : {batch_size} actors per SPARQL query")
+    print(f"  Total batches     : {n_batches}")
+    if industry_filter:
+        print(f"  Industry filter   : {industry_filter}")
+    print(f"{_BOLD}\n")
+
+
+def _print_batch_header(batch_num: int, total_batches: int, names: list[str]) -> None:
+    print(f"\n{'─' * 64}")
+    print(
+        f"  Batch {batch_num}/{total_batches}  "
+        f"({len(names)} actor{'s' if len(names) != 1 else ''})"
+    )
+    for name in names:
+        print(f"    • {name}")
+    print(f"{'─' * 64}")
+
+
+def _print_final_summary(
+    results: list[dict],
+    errors: list[tuple[str, str]],
+    elapsed: float,
+) -> None:
+    total_films    = sum(r["total"]    for r in results)
+    total_inserted = sum(r["inserted"] for r in results)
+    total_skipped  = sum(r["skipped"]  for r in results)
+
+    print(f"\n{_BOLD}")
+    print("  Ingestion complete")
+    print(f"{_THIN}")
+    print(f"  Actors processed : {len(results)}")
+    print(f"  Films found      : {total_films}")
+    print(f"  Movies inserted  : {total_inserted}")
+    print(f"  Movies skipped   : {total_skipped}  (already existed)")
+    if errors:
+        print(f"  Errors           : {len(errors)}")
+        for actor_name, err_msg in errors:
+            print(f"    ✗ {actor_name}: {err_msg}")
+    print(f"  Elapsed          : {elapsed:.1f} s")
+    print(f"{_BOLD}\n")
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _group_rows_by_actor(rows: list[dict]) -> dict[str, list[dict]]:
+    """
+    Group a flat list of (actor, film) row dicts by actor QID.
+
+    Args:
+        rows: Flat list returned by ``fetch_filmography_batch``.
+              Each dict has at minimum: ``actor_qid``, ``actor_name``,
+              ``film_title``, ``release_year``, ``director``.
+
+    Returns:
+        Dict mapping ``actor_qid`` → list of row dicts for that actor.
+    """
+    grouped: dict[str, list[dict]] = defaultdict(list)
+    for row in rows:
+        grouped[row["actor_qid"]].append(row)
+    return dict(grouped)
+
+
+def _write_actor_films(
+    db:       Session,
+    name:     str,
+    qid:      str,
+    industry: str,
+    films:    list[dict],
+) -> dict:
+    """
+    Upsert one actor and all their films into the DB within a single transaction.
+
+    Commits after all of the actor's films are written.  A rollback on error
+    only affects this actor, not the whole batch.
+
+    Args:
+        db:       Active SQLAlchemy session.
+        name:     Actor display name (from Wikidata label or registry).
+        qid:      Wikidata QID, e.g. ``"Q352416"``.
+        industry: Industry label inherited from actor_registry, e.g. ``"Telugu"``.
+        films:    List of row dicts from ``fetch_filmography_batch`` for this actor.
+                  Each dict: ``{"film_title", "release_year", "director", ...}``.
+
+    Returns:
+        Stats dict::
+
+            {
+                "actor":    "Allu Arjun",
+                "qid":      "Q352416",
+                "total":    24,
+                "inserted": 2,
+                "skipped":  22,
+            }
+
+    Raises:
+        Exception: re-raises any DB error after rolling back this actor's writes.
+    """
+    inserted = 0
+    skipped  = 0
+
+    try:
+        # Step 1 — Upsert actor
+        actor = _get_or_create_actor(db, name, industry)
+
+        # Steps 2-4 — Per-film upserts
+        for row in films:
+            title    = row["film_title"]
+            year: Optional[int] = row.get("release_year")
+            dir_name: Optional[str] = row.get("director")
+
+            # Step 2: upsert movie (keeps legacy director TEXT in sync)
+            movie, is_new = _get_or_create_movie(
+                db,
+                title=title,
+                year=year,
+                director=dir_name,
+                industry=industry,
+            )
+            if is_new:
+                inserted += 1
+            else:
+                skipped += 1
+
+            # Step 3: upsert director + join row (when known)
+            if dir_name:
+                director_obj = _get_or_create_director(db, dir_name)
+                _get_or_create_movie_director(db, movie.id, director_obj.id)
+
+            # Step 4: upsert cast link (actor ↔ movie)
+            _get_or_create_cast(db, actor.id, movie.id)
+
+        db.commit()
+
+    except Exception:
+        db.rollback()
+        raise
+
+    return {
+        "actor":    name,
+        "qid":      qid,
+        "total":    len(films),
+        "inserted": inserted,
+        "skipped":  skipped,
+    }
+
+
+def _process_batch(
+    batch:         list[tuple[str, str, str]],
+    batch_num:     int,
+    total_batches: int,
+    dry_run:       bool,
+) -> tuple[list[dict], list[tuple[str, str]]]:
+    """
+    Fetch and ingest one batch of actors.
+
+    Issues a SINGLE Wikidata SPARQL request for all actors in *batch*, then
+    writes each actor's films to the DB individually (so one DB failure never
+    rolls back another actor's data).
+
+    Args:
+        batch:         List of ``(name, qid, industry)`` triples.
+        batch_num:     1-based batch index (for logging).
+        total_batches: Total number of batches (for logging).
+        dry_run:       If True, skip all DB writes.
+
+    Returns:
+        Tuple of (results, errors):
+          - results: list of stats dicts (one per successfully processed actor)
+          - errors:  list of (actor_name, error_message) for failed actors
+    """
+    names    = [t[0] for t in batch]
+    qids     = [t[1] for t in batch]
+
+    _print_batch_header(batch_num, total_batches, names)
+
+    label = f"batch {batch_num}/{total_batches}, {len(batch)} actors"
+
+    # ── ONE Wikidata request for the whole batch ──────────────────────────
+    rows = fetch_filmography_batch(qids, label=label)
+    print(f"  → Fetched {len(rows)} film row(s) across {len(batch)} actor(s).")
+
+    if dry_run:
+        print("  [DRY RUN] Skipping all DB writes.")
+        results = []
+        for name, qid, _industry in batch:
+            actor_rows = [r for r in rows if r["actor_qid"] == qid]
+            results.append({
+                "actor":    name,
+                "qid":      qid,
+                "total":    len(actor_rows),
+                "inserted": 0,
+                "skipped":  len(actor_rows),
+            })
+        return results, []
+
+    # ── Group rows by actor QID ───────────────────────────────────────────
+    grouped = _group_rows_by_actor(rows)
+
+    results: list[dict]            = []
+    errors:  list[tuple[str, str]] = []
+
+    # ── Per-actor DB writes ───────────────────────────────────────────────
+    for name, qid, industry in batch:
+        actor_rows = grouped.get(qid, [])
+
+        if not actor_rows:
+            print(f"\n  ⚠  No films found for {name} ({qid}) in batch results.")
+            print(f"     Verify QID at: https://www.wikidata.org/wiki/{qid}")
+            results.append({
+                "actor":    name,
+                "qid":      qid,
+                "total":    0,
+                "inserted": 0,
+                "skipped":  0,
+            })
+            continue
+
+        # Use Wikidata actor_name label when available; fall back to registry name.
+        wikidata_name = actor_rows[0].get("actor_name") or name
+        display_name  = wikidata_name if wikidata_name and wikidata_name != qid else name
+
+        print(f"\n  Processing : {display_name} ({qid})  [{industry}]")
+        print(f"    {len(actor_rows)} film row(s) to process.")
+
+        db: Session = SessionLocal()
+        try:
+            stats = _write_actor_films(db, display_name, qid, industry, actor_rows)
+            results.append(stats)
+            print(
+                f"  ✓ {display_name}: "
+                f"{stats['total']} films | "
+                f"{stats['inserted']} inserted | "
+                f"{stats['skipped']} skipped"
+            )
+
+        except Exception as exc:
+            err_msg = str(exc).splitlines()[0]
+            print(f"  ✗ FAILED: {display_name} ({qid}) — {err_msg}")
+            errors.append((display_name, err_msg))
+
+        finally:
+            db.close()
+
+    return results, errors
+
+
+# ---------------------------------------------------------------------------
+# Main driver
+# ---------------------------------------------------------------------------
+
+def ingest_all_actors(
+    batch_size:      int  = BATCH_SIZE,
+    industry_filter: str  = "",
+    limit:           int  = 0,
+    dry_run:         bool = False,
+) -> int:
+    """
+    Load actor_registry, split into batches, and ingest each batch from Wikidata.
+
+    Args:
+        batch_size:      Number of actors per SPARQL query (default: BATCH_SIZE=20).
+        industry_filter: If non-empty, only process actors whose industry matches
+                         this string exactly (e.g. ``"Telugu"``).
+        limit:           Max number of actors to process (0 = no limit).
+        dry_run:         If True, query Wikidata but do not write to DB.
+
+    Returns:
+        Exit code — 0 if all actors succeeded, 1 if any errors occurred.
+    """
+    # ── Load actor registry ────────────────────────────────────────────────
+    db = SessionLocal()
+    try:
+        q = db.query(ActorRegistry).order_by(
+            ActorRegistry.industry, ActorRegistry.name
+        )
+        if industry_filter:
+            q = q.filter(ActorRegistry.industry == industry_filter)
+        if limit > 0:
+            q = q.limit(limit)
+        registry_entries = q.all()
+
+        # Detach before closing so we don't hold an idle connection during
+        # the long-running ingestion loop.
+        actors: list[tuple[str, str, str]] = [
+            (entry.name, entry.wikidata_id, entry.industry)
+            for entry in registry_entries
+        ]
+    finally:
+        db.close()
+
+    if not actors:
+        msg = "actor_registry"
+        if industry_filter:
+            msg += f" (industry={industry_filter!r})"
+        print(
+            f"\nNo actors found in {msg}.  "
+            f"Run the SQL migration to populate it.\n"
+        )
+        return 0
+
+    # ── Start pipeline run tracking ────────────────────────────────────────
+    run_id = _start_pipeline_run("wikidata_ingestion")
+
+    effective_batch_size = max(1, batch_size)
+    batches = [
+        actors[i : i + effective_batch_size]
+        for i in range(0, len(actors), effective_batch_size)
+    ]
+
+    _print_run_header(
+        total=len(actors),
+        batch_size=effective_batch_size,
+        industry_filter=industry_filter,
+        dry_run=dry_run,
+    )
+
+    # ── Batch ingestion loop ───────────────────────────────────────────────
+    all_results: list[dict]            = []
+    all_errors:  list[tuple[str, str]] = []
+    start = time.monotonic()
+
+    for batch_num, batch in enumerate(batches, start=1):
+        batch_results, batch_errors = _process_batch(
+            batch=batch,
+            batch_num=batch_num,
+            total_batches=len(batches),
+            dry_run=dry_run,
+        )
+        all_results.extend(batch_results)
+        all_errors.extend(batch_errors)
+
+        # Rate-limit: sleep between batches (not before the first one —
+        # fetch_filmography_batch already sleeps REQUEST_DELAY internally).
+        if batch_num < len(batches):
+            print(f"\n  ⏳ Sleeping 1 s before next batch...")
+            time.sleep(1)
+
+    elapsed = time.monotonic() - start
+    _print_final_summary(all_results, all_errors, elapsed)
+
+    # ── Finish pipeline run tracking ───────────────────────────────────────
+    final_status = "failed" if all_errors and not all_results else "success"
+    _finish_pipeline_run(run_id, final_status, {
+        "actors_processed": len(all_results),
+        "actors_failed":    len(all_errors),
+        "films_found":      sum(r.get("total",    0) for r in all_results),
+        "movies_inserted":  sum(r.get("inserted", 0) for r in all_results),
+        "movies_skipped":   sum(r.get("skipped",  0) for r in all_results),
+        "elapsed_s":        round(elapsed, 1),
+        "dry_run":          dry_run,
+        "batch_size":       effective_batch_size,
+    })
+
+    return 1 if all_errors else 0
+
+
+# ---------------------------------------------------------------------------
+# CLI entry-point
+# ---------------------------------------------------------------------------
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="ingest_all_actors",
+        description=(
+            "Batch-ingest South Indian actor filmographies from Wikidata "
+            "using QIDs stored in actor_registry.  Issues ONE SPARQL query "
+            "per batch of --batch-size actors (default 20) instead of one "
+            "query per actor."
+        ),
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=BATCH_SIZE,
+        metavar="N",
+        help=(
+            f"Actors per SPARQL query (default: {BATCH_SIZE}).  "
+            "Reduce if you hit Wikidata query timeouts."
+        ),
+    )
+    parser.add_argument(
+        "--industry",
+        type=str,
+        default="",
+        metavar="INDUSTRY",
+        help='Only process actors from this industry (e.g. "Telugu", "Tamil").',
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Query Wikidata and print results without writing to the database.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        metavar="N",
+        help="Process at most N actors (default: 0 = no limit).  Useful for testing.",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    rc   = ingest_all_actors(
+        batch_size=args.batch_size,
+        industry_filter=args.industry,
+        limit=args.limit,
+        dry_run=args.dry_run,
+    )
+    sys.exit(rc)

--- a/backend/data_pipeline/refresh_analytics_views.py
+++ b/backend/data_pipeline/refresh_analytics_views.py
@@ -1,0 +1,204 @@
+"""
+refresh_analytics_views.py
+===========================
+Refreshes the Sprint 4 analytics materialized views after data ingestion or
+enrichment runs.
+
+Why refresh?
+------------
+PostgreSQL materialized views cache query results at creation time and do NOT
+update automatically when the underlying tables change.  After every Wikidata
+ingestion or Wikipedia enrichment run, this script must be executed to bring
+the views up to date.
+
+Views refreshed
+---------------
+  actor_film_counts
+      One row per actor: actor_id, actor_name, industry, film_count.
+      Used by leaderboard / "top actors" dashboard queries.
+
+  actor_director_collaborations
+      One row per (actor, director) pair: actor, industry, director,
+      collaborations.
+      Used by collaboration charts.
+
+Refresh strategy
+----------------
+Both views have a UNIQUE index on their primary key column, which allows
+``REFRESH MATERIALIZED VIEW CONCURRENTLY``.  Concurrent refresh means the
+old view data remains readable while the new data is being computed — no
+downtime for dashboard users.
+
+Pipeline run tracking
+---------------------
+Records the refresh in the pipeline_runs table (run_type = "view_refresh").
+If the table does not exist (migration not applied) the script still runs;
+only the tracking step is skipped with a warning.
+
+Requires
+--------
+  sprint4_materialized_views.sql must be applied before this script is run.
+
+Usage
+-----
+    # From the backend/ directory:
+    python -m data_pipeline.refresh_analytics_views
+
+    # Or directly:
+    python data_pipeline/refresh_analytics_views.py
+
+Environment
+-----------
+    DATABASE_URL  – PostgreSQL DSN
+                    Default: postgresql://sca:sca@postgres:5432/sca
+"""
+
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# Path bootstrap
+# ---------------------------------------------------------------------------
+_BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+from sqlalchemy import text
+
+from app.database import SessionLocal
+
+# ---------------------------------------------------------------------------
+# Views to refresh, in dependency order.
+# Each entry: (view_name, use_concurrent_refresh)
+# CONCURRENTLY requires a UNIQUE index on the view — both views have one.
+# ---------------------------------------------------------------------------
+
+VIEWS: list[tuple[str, bool]] = [
+    ("actor_film_counts",           True),
+    ("actor_director_collaborations", False),  # no unique index → standard refresh
+]
+
+_BOLD = "=" * 56
+_THIN = "-" * 56
+
+
+# ---------------------------------------------------------------------------
+# Pipeline run tracking helpers
+# ---------------------------------------------------------------------------
+
+def _start_run() -> Optional[int]:
+    """Insert a pipeline_runs row for this refresh.  Returns id or None."""
+    try:
+        from app.models import PipelineRun
+        db = SessionLocal()
+        try:
+            run = PipelineRun(
+                run_type="view_refresh",
+                started_at=datetime.now(timezone.utc),
+                status="running",
+            )
+            db.add(run)
+            db.commit()
+            db.refresh(run)
+            return run.id
+        finally:
+            db.close()
+    except Exception as exc:
+        print(f"  [pipeline_runs] Warning: could not record run start — {exc}")
+        return None
+
+
+def _finish_run(run_id: Optional[int], status: str, details: dict) -> None:
+    """Update the pipeline_runs row with final status and stats."""
+    if run_id is None:
+        return
+    try:
+        from app.models import PipelineRun
+        db = SessionLocal()
+        try:
+            run = db.query(PipelineRun).filter(PipelineRun.id == run_id).first()
+            if run:
+                run.finished_at = datetime.now(timezone.utc)
+                run.status      = status
+                run.details     = json.dumps(details)
+                db.commit()
+        finally:
+            db.close()
+    except Exception as exc:
+        print(f"  [pipeline_runs] Warning: could not update run record — {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Main refresh logic
+# ---------------------------------------------------------------------------
+
+def refresh_analytics_views() -> int:
+    """
+    Refresh all analytics materialized views.
+
+    Returns:
+        Exit code — 0 if all views refreshed successfully, 1 if any errors.
+    """
+    print(f"\n{_BOLD}")
+    print("  South Cinema Analytics — Refresh Analytics Views")
+    print(f"{_BOLD}\n")
+
+    start_time = time.monotonic()
+    run_id     = _start_run()
+
+    refreshed: list[str] = []
+    failed:    list[str] = []
+
+    # Use a raw connection for DDL statements; autocommit=True is required for
+    # REFRESH MATERIALIZED VIEW CONCURRENTLY (cannot run inside a transaction).
+    with SessionLocal().connection() as conn:
+        conn.execution_options(isolation_level="AUTOCOMMIT")
+
+        for view_name, concurrent in VIEWS:
+            keyword = "CONCURRENTLY" if concurrent else ""
+            sql     = f"REFRESH MATERIALIZED VIEW {keyword} {view_name}"
+
+            print(f"  Refreshing : {view_name} ...", end=" ", flush=True)
+            t0 = time.monotonic()
+
+            try:
+                conn.execute(text(sql))
+                elapsed_ms = int((time.monotonic() - t0) * 1000)
+                print(f"✓  ({elapsed_ms} ms)")
+                refreshed.append(view_name)
+
+            except Exception as exc:
+                print(f"✗")
+                print(f"    Error: {exc}")
+                failed.append(view_name)
+
+    total_elapsed = time.monotonic() - start_time
+
+    # ── Summary ──────────────────────────────────────────────────────────────
+    print(f"\n{_THIN}")
+    print(f"  Refreshed : {len(refreshed)}  view(s)")
+    if failed:
+        print(f"  Failed    : {len(failed)}  view(s): {', '.join(failed)}")
+    print(f"  Elapsed   : {total_elapsed:.1f} s")
+    print(f"{_BOLD}\n")
+
+    final_status = "success" if not failed else "failed"
+    _finish_run(run_id, final_status, {
+        "refreshed": refreshed,
+        "failed":    failed,
+        "elapsed_s": round(total_elapsed, 1),
+    })
+
+    return 0 if not failed else 1
+
+
+# ---------------------------------------------------------------------------
+# CLI entry-point
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    sys.exit(refresh_analytics_views())

--- a/backend/data_pipeline/wikidata_batch_client.py
+++ b/backend/data_pipeline/wikidata_batch_client.py
@@ -1,0 +1,413 @@
+"""
+wikidata_batch_client.py
+========================
+Fetches South Indian cinema data from Wikidata in *batch* mode.
+
+Why batching?
+-------------
+The single-actor client (wikidata_client.py) issues one SPARQL request per
+actor.  With 13 actors that is 13 sequential HTTP calls and 13+ seconds of
+wall-clock time just in rate-limit delays.
+
+This module issues ONE SPARQL request per batch of up to BATCH_SIZE actors by
+using the SPARQL ``VALUES`` clause to enumerate multiple actor QIDs in a single
+query.  A batch of 20 actors that would have cost 20 s now costs ~1 s of delay
+plus one network round-trip.
+
+Public API
+----------
+    fetch_filmography_batch(actor_qids, label="") -> list[dict]
+
+        Each dict represents one (actor, film) row:
+            {
+                "actor_qid":   "Q352416",
+                "actor_name":  "Allu Arjun",      # from Wikidata label service
+                "film_title":  "Pushpa: The Rise",
+                "release_year": 2021,              # int or None
+                "director":    "Sukumar"           # str or None
+            }
+
+        Duplicate rows (caused by films with multiple directors) are collapsed
+        in Python before the list is returned.  Only the first director seen for
+        each (actor_qid, film_title, release_year) triple is kept.
+
+Compatibility
+-------------
+This module is a sibling of wikidata_client.py, NOT a replacement.  The single-
+actor client remains available for one-off debugging:
+    python -m data_pipeline.wikidata_client Q352416 "Allu Arjun"
+
+Sprint 4 change — Retry logic (Task 4)
+----------------------------------------
+A urllib3 Retry strategy is now mounted on the shared requests.Session:
+  - 3 total retries
+  - Exponential backoff: 1 s → 2 s → 4 s
+  - Retries on HTTP 429 (rate limited), 500, 502, 503, 504
+Batch SPARQL queries are longer-running than single-actor queries, making
+them more susceptible to transient timeouts; retries provide resilience.
+
+Polite usage rules
+------------------
+  - Descriptive User-Agent header identifies this service to Wikidata ops.
+  - REQUEST_DELAY (1 s) sleep *between batches* (not per-actor) keeps throughput
+    high while respecting Wikidata's fair-use policy.
+    https://www.mediawiki.org/wiki/Wikidata_Query_Service/User_Manual
+  - 60-second timeout per request; batch queries can be slower than single ones.
+  - LIMIT 5000 per query guards against unexpectedly large result sets.
+
+Standalone test:
+    python -m data_pipeline.wikidata_batch_client Q352416 Q297491 Q536725
+"""
+
+import json
+import re
+import sys
+import time
+from collections import defaultdict
+from typing import Optional
+
+from requests import Session
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+SPARQL_ENDPOINT = "https://query.wikidata.org/sparql"
+
+# Delay between *batch* requests (not per-actor — that's the whole point).
+REQUEST_DELAY: float = 1.0
+
+# Default actors per SPARQL query.  Wikidata handles 20 comfortably; going
+# higher risks query timeouts on complex filmographies.
+BATCH_SIZE: int = 20
+
+# Safety ceiling: warn if results hit this limit (possible truncation).
+RESULT_LIMIT: int = 5000
+
+USER_AGENT = (
+    "SouthCinemaAnalytics/1.0 "
+    "(https://github.com/south-cinema-analytics; "
+    "contact@south-cinema-analytics.example) "
+    "Python/3.11 requests"
+)
+
+# Valid QID: "Q" followed by one or more digits.
+_QID_RE = re.compile(r"^Q\d+$")
+
+
+# ---------------------------------------------------------------------------
+# Session with retry logic (Task 4)
+# ---------------------------------------------------------------------------
+
+def _build_session() -> Session:
+    """
+    Create a requests.Session with automatic retry on transient errors.
+
+    Retry configuration:
+      - total=3          : up to 3 retry attempts per request
+      - backoff_factor=1 : sleep 1 s, 2 s, 4 s between attempts
+      - status_forcelist : retry on 429 (rate limited), 5xx server errors
+      - raise_on_status=False : let _sparql_query() call raise_for_status()
+
+    Batch SPARQL queries are slower than single-actor queries, so transient
+    timeouts are more likely; retries provide an important safety net.
+
+    Returns:
+        Configured Session instance.
+    """
+    retry = Retry(
+        total=3,
+        backoff_factor=1,
+        status_forcelist=[429, 500, 502, 503, 504],
+        raise_on_status=False,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session = Session()
+    session.mount("https://", adapter)
+    session.mount("http://",  adapter)
+    return session
+
+
+# Module-level session: shared and reused across all batch calls in a process.
+_SESSION: Session = _build_session()
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _validate_qids(qids: list[str]) -> list[str]:
+    """
+    Validate and normalise a list of Wikidata QIDs.
+
+    Uppercases the "Q" prefix and strips whitespace so inputs like
+    "q352416" or " Q297491 " are silently corrected.
+
+    Args:
+        qids: Raw QID strings from the caller.
+
+    Returns:
+        List of normalised QID strings.
+
+    Raises:
+        ValueError: if any element does not match the QID format after
+                    normalisation, or if the list is empty.
+    """
+    if not qids:
+        raise ValueError("fetch_filmography_batch: actor_qids list must not be empty.")
+
+    result = []
+    for raw in qids:
+        qid = raw.strip().upper()
+        if not _QID_RE.match(qid):
+            raise ValueError(
+                f"Invalid Wikidata QID {raw!r}.  "
+                f"Expected 'Q' followed by digits, e.g. 'Q352416'."
+            )
+        result.append(qid)
+    return result
+
+
+def _build_values_block(qids: list[str]) -> str:
+    """
+    Build the SPARQL VALUES block for a list of QIDs.
+
+    Example output for ["Q352416", "Q297491"]:
+        wd:Q352416
+        wd:Q297491
+
+    Args:
+        qids: Normalised QID strings.
+
+    Returns:
+        Multi-line string for insertion into the VALUES clause.
+    """
+    return "\n    ".join(f"wd:{qid}" for qid in qids)
+
+
+def _qid_from_uri(uri: str) -> str:
+    """
+    Extract the QID from a Wikidata entity URI.
+
+    Example:
+        "http://www.wikidata.org/entity/Q352416"  →  "Q352416"
+
+    Args:
+        uri: Full Wikidata entity IRI from the SPARQL JSON response.
+
+    Returns:
+        QID string, e.g. "Q352416".
+    """
+    return uri.rsplit("/", 1)[-1]
+
+
+def _is_unresolved_qid(value: str) -> bool:
+    """
+    Return True if *value* is a raw Wikidata entity ID (e.g. "Q123456").
+
+    The label service falls back to the entity ID when no English label
+    exists.  We filter these out so unresolved IDs never reach the database.
+    """
+    return bool(value) and _QID_RE.match(value) is not None
+
+
+def _sparql_query(query: str) -> dict:
+    """
+    Execute a SPARQL SELECT query against the Wikidata endpoint.
+
+    Sleeps REQUEST_DELAY seconds *before* sending so every batch call
+    automatically respects the rate limit without extra bookkeeping.
+    The session-level Retry adapter handles transient failures automatically.
+
+    Args:
+        query: SPARQL SELECT query string.
+
+    Returns:
+        Parsed JSON response (SPARQL 1.1 results format).
+
+    Raises:
+        requests.HTTPError: on 4xx / 5xx status codes (after retries exhausted).
+        requests.Timeout:   if the server doesn't respond within 60 s.
+    """
+    time.sleep(REQUEST_DELAY)
+
+    headers = {
+        "User-Agent": USER_AGENT,
+        "Accept":     "application/sparql-results+json",
+    }
+    response = _SESSION.get(
+        SPARQL_ENDPOINT,
+        params={"query": query, "format": "json"},
+        headers=headers,
+        timeout=60,   # batch queries can be slower than single-actor ones
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def fetch_filmography_batch(
+    actor_qids: list[str],
+    label:      str = "",
+) -> list[dict]:
+    """
+    Fetch filmographies for multiple actors in a single SPARQL query.
+
+    The query uses a ``VALUES`` clause to enumerate all actor QIDs at once.
+    Results are returned as a flat list of (actor, film) row dicts.
+
+    SPARQL strategy
+    ---------------
+    ``?film wdt:P161 ?actor`` finds all films in which *?actor* was a cast
+    member.  Filtering ``?film wdt:P31/wdt:P279* wd:Q11424`` keeps only
+    theatrical films (excluding TV episodes, documentaries, shorts, etc.).
+
+    Deduplication
+    -------------
+    A film with multiple Wikidata directors produces one result row per
+    director.  This function deduplicates on ``(actor_qid, film_title,
+    release_year)`` and keeps only the first director encountered per triple.
+
+    Args:
+        actor_qids: List of Wikidata QIDs, e.g. ["Q352416", "Q297491"].
+                    Case-insensitive; whitespace is stripped automatically.
+                    Maximum recommended size: BATCH_SIZE (20).
+        label:      Optional human-readable label printed in progress output,
+                    e.g. "batch 1/3".  Defaults to "batch of N actors".
+
+    Returns:
+        Flat list of dicts, one per unique (actor, film) pair::
+
+            [
+                {
+                    "actor_qid":    "Q352416",
+                    "actor_name":   "Allu Arjun",
+                    "film_title":   "Pushpa: The Rise",
+                    "release_year": 2021,       # int or None
+                    "director":     "Sukumar"   # str or None
+                },
+                ...
+            ]
+
+    Raises:
+        ValueError:           if *actor_qids* is empty or contains invalid QIDs.
+        requests.HTTPError:   on Wikidata API errors.
+        requests.Timeout:     if the SPARQL endpoint is unresponsive.
+    """
+    validated_qids = _validate_qids(actor_qids)
+    values_block   = _build_values_block(validated_qids)
+    display_label  = label or f"batch of {len(validated_qids)} actor(s)"
+
+    query = f"""
+    SELECT ?actor ?actorLabel ?film ?filmLabel ?releaseYear ?directorLabel WHERE {{
+
+      # ── Actor set — enumerate all QIDs in a single VALUES clause ───────────
+      VALUES ?actor {{
+        {values_block}
+      }}
+
+      # ── Films each actor appeared in ────────────────────────────────────────
+      ?film wdt:P161 ?actor .
+
+      # Restrict to theatrical films and their Wikidata subclasses.
+      # Excludes: TV episodes, documentaries, web series, short films, etc.
+      ?film wdt:P31/wdt:P279* wd:Q11424 .
+
+      # ── Optional metadata ──────────────────────────────────────────────────
+      OPTIONAL {{
+        ?film wdt:P577 ?releaseDate .
+        BIND(YEAR(?releaseDate) AS ?releaseYear)
+      }}
+      OPTIONAL {{
+        ?film wdt:P57 ?director .
+      }}
+
+      # Resolve human-readable labels in English.
+      SERVICE wikibase:label {{
+        bd:serviceParam wikibase:language "en" .
+      }}
+    }}
+    ORDER BY ?actor ?releaseYear
+    LIMIT {RESULT_LIMIT}
+    """
+
+    print(f"  → Querying Wikidata ({display_label}) ...")
+    raw      = _sparql_query(query)
+    bindings = raw.get("results", {}).get("bindings", [])
+
+    if len(bindings) >= RESULT_LIMIT:
+        print(
+            f"  ⚠  Result count hit the LIMIT of {RESULT_LIMIT}.  "
+            f"Some films may be missing.  Consider reducing BATCH_SIZE."
+        )
+
+    # ── Parse and deduplicate ─────────────────────────────────────────────────
+    # Key: (actor_qid, film_title, release_year) — one row per unique triple.
+    seen:  set[tuple]  = set()
+    rows:  list[dict]  = []
+
+    for binding in bindings:
+        actor_uri    = binding.get("actor",         {}).get("value", "")
+        actor_name   = binding.get("actorLabel",    {}).get("value", "")
+        film_title   = binding.get("filmLabel",     {}).get("value", "")
+        year_raw     = binding.get("releaseYear",   {}).get("value")
+        director_raw = binding.get("directorLabel", {}).get("value", "")
+
+        # Extract QID from the entity URI.
+        actor_qid = _qid_from_uri(actor_uri) if actor_uri else ""
+        if not actor_qid or not _QID_RE.match(actor_qid):
+            continue   # skip malformed actor URI
+
+        # Skip rows where the label service returned a raw entity ID.
+        if not film_title or _is_unresolved_qid(film_title):
+            continue
+
+        year: Optional[int] = int(year_raw) if year_raw else None
+
+        director: Optional[str] = (
+            director_raw
+            if director_raw and not _is_unresolved_qid(director_raw)
+            else None
+        )
+
+        key = (actor_qid, film_title, year)
+        if key in seen:
+            continue   # duplicate from multi-director film — skip
+        seen.add(key)
+
+        rows.append({
+            "actor_qid":    actor_qid,
+            "actor_name":   actor_name,
+            "film_title":   film_title,
+            "release_year": year,
+            "director":     director,
+        })
+
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Standalone test entry-point
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python -m data_pipeline.wikidata_batch_client <QID1> [QID2 ...]")
+        print()
+        print("Examples:")
+        print("  python -m data_pipeline.wikidata_batch_client Q352416 Q297491")
+        print("  python -m data_pipeline.wikidata_batch_client Q536725 Q351478 Q330829")
+        sys.exit(1)
+
+    _qids  = sys.argv[1:]
+    _rows  = fetch_filmography_batch(_qids, label="test")
+    print(f"\nReturned {len(_rows)} row(s):\n")
+    print(json.dumps(_rows[:20], indent=2, ensure_ascii=False))
+    if len(_rows) > 20:
+        print(f"  … and {len(_rows) - 20} more rows")

--- a/backend/data_pipeline/wikidata_client.py
+++ b/backend/data_pipeline/wikidata_client.py
@@ -1,0 +1,324 @@
+"""
+wikidata_client.py
+==================
+Fetches South Indian cinema data from the Wikidata public SPARQL endpoint.
+
+Sprint 3 change — QID-based lookups
+-------------------------------------
+The previous implementation resolved actors by matching their English rdfs:label,
+which was fragile:  common names ("Vijay") matched multiple entities, and
+diacritics / alternate spellings caused missed results.
+
+This version resolves actors via their canonical Wikidata QID (e.g. Q352416
+for Allu Arjun).  Querying `wd:Q352416` is unambiguous, faster, and immune
+to label-language issues.
+
+Sprint 4 change — Retry logic (Task 4)
+----------------------------------------
+A urllib3 Retry strategy is now mounted on the shared requests.Session:
+  - 3 total retries
+  - Exponential backoff: 1 s → 2 s → 4 s
+  - Retries on HTTP 429, 500, 502, 503, 504
+This handles Wikidata rate-limit bursts and transient server errors without
+any changes to calling code.
+
+Polite usage rules (unchanged from Sprint 2):
+  - Descriptive User-Agent header identifies our service to Wikidata ops.
+  - REQUEST_DELAY (1 s) between every HTTP call respects Wikidata's fair-use
+    guidelines.  https://www.mediawiki.org/wiki/Wikidata_Query_Service/User_Manual
+  - 30-second timeout prevents hung connections from stalling the pipeline.
+
+Usage (standalone test):
+    python -m data_pipeline.wikidata_client Q352416            # Allu Arjun
+    python -m data_pipeline.wikidata_client Q297491 "Prabhas"  # named output
+"""
+
+import json
+import re
+import sys
+import time
+from typing import Optional
+
+from requests import Session
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+SPARQL_ENDPOINT = "https://query.wikidata.org/sparql"
+
+# 1 request per second — required by Wikidata's terms of service.
+REQUEST_DELAY: float = 1.0
+
+USER_AGENT = (
+    "SouthCinemaAnalytics/1.0 "
+    "(https://github.com/south-cinema-analytics; "
+    "contact@south-cinema-analytics.example) "
+    "Python/3.11 requests"
+)
+
+# Valid QID pattern: "Q" followed by one or more digits.
+_QID_RE = re.compile(r"^Q\d+$")
+
+
+# ---------------------------------------------------------------------------
+# Session with retry logic (Task 4)
+# ---------------------------------------------------------------------------
+
+def _build_session() -> Session:
+    """
+    Create a requests.Session with automatic retry on transient errors.
+
+    Retry configuration:
+      - total=3          : up to 3 retry attempts per request
+      - backoff_factor=1 : sleep 1 s, 2 s, 4 s between attempts
+      - status_forcelist : retry on 429 (rate limited), 5xx server errors
+      - raise_on_status=False : let _sparql_query() call raise_for_status()
+
+    Returns:
+        Configured Session instance.
+    """
+    retry = Retry(
+        total=3,
+        backoff_factor=1,
+        status_forcelist=[429, 500, 502, 503, 504],
+        raise_on_status=False,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session = Session()
+    session.mount("https://", adapter)
+    session.mount("http://",  adapter)
+    return session
+
+
+# Module-level session: shared and reused across all calls in a process.
+_SESSION: Session = _build_session()
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _validate_qid(wikidata_id: str) -> str:
+    """
+    Validate and normalise a Wikidata QID string.
+
+    Strips leading/trailing whitespace and uppercases the "Q" prefix so that
+    inputs like "q352416" or " Q352416 " are silently corrected.
+
+    Args:
+        wikidata_id: Raw QID string from the caller.
+
+    Returns:
+        Normalised QID string, e.g. "Q352416".
+
+    Raises:
+        ValueError: if the string does not match the QID format after normalisation.
+    """
+    qid = wikidata_id.strip().upper()
+    if not _QID_RE.match(qid):
+        raise ValueError(
+            f"Invalid Wikidata QID {wikidata_id!r}.  "
+            f"Expected format: Q followed by digits, e.g. 'Q352416'."
+        )
+    return qid
+
+
+def _sparql_query(query: str) -> dict:
+    """
+    Execute a SPARQL SELECT query against the Wikidata endpoint.
+
+    Sleeps REQUEST_DELAY seconds *before* the HTTP call so every caller
+    automatically respects the rate limit without extra bookkeeping.
+    The session-level Retry adapter handles transient failures automatically.
+
+    Args:
+        query: SPARQL SELECT query string.
+
+    Returns:
+        Parsed JSON response dict (SPARQL 1.1 results format).
+
+    Raises:
+        requests.HTTPError: on 4xx / 5xx status codes (after retries exhausted).
+        requests.Timeout:   if the server doesn't respond within 30 s.
+    """
+    time.sleep(REQUEST_DELAY)
+
+    headers = {
+        "User-Agent": USER_AGENT,
+        "Accept":     "application/sparql-results+json",
+    }
+    response = _SESSION.get(
+        SPARQL_ENDPOINT,
+        params={"query": query, "format": "json"},
+        headers=headers,
+        timeout=30,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def _is_unresolved_qid(value: str) -> bool:
+    """
+    Return True if *value* is an unresolved Wikidata entity ID (e.g. "Q123456").
+
+    When the label service cannot resolve a label it falls back to the raw
+    entity IRI.  We filter these out so junk never reaches the database.
+    """
+    return bool(value) and _QID_RE.match(value) is not None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def fetch_actor_filmography(wikidata_id: str, actor_name: str = "") -> dict:
+    """
+    Fetch every film in which the given actor appeared, using their Wikidata
+    QID for a precise, unambiguous lookup.
+
+    SPARQL strategy
+    ---------------
+    The query uses the *reverse property path* ``^wdt:P161`` which reads as
+    "find all entities X such that X has cast member = wd:<QID>", i.e.
+    "all films this actor appeared in".  This is equivalent to::
+
+        ?film wdt:P161 wd:<QID>
+
+    but written in the compact Turtle form preferred by the task spec.
+
+    Additional constraints:
+      - ``?film wdt:P31/wdt:P279* wd:Q11424``  — restrict to theatrical films
+        and their subclasses; excludes TV episodes, shorts, documentaries, etc.
+      - OPTIONAL release date and director — not every film has these on Wikidata.
+
+    Deduplication
+    -------------
+    A single film can appear multiple times in SPARQL results when it has more
+    than one director listed on Wikidata (one binding per director).  We
+    deduplicate by ``(title, releaseYear)`` in Python and keep only the first
+    director encountered for each pair.
+
+    Args:
+        wikidata_id: Wikidata entity ID of the actor, e.g. ``"Q352416"``
+                     (Allu Arjun).  Case-insensitive; leading/trailing
+                     whitespace is stripped automatically.
+        actor_name:  Optional human-readable name used only for the ``"actor"``
+                     field in the returned dict.  Defaults to *wikidata_id*
+                     when empty.
+
+    Returns:
+        Dict with the structure::
+
+            {
+                "actor": "Allu Arjun",       # actor_name or wikidata_id
+                "wikidata_id": "Q352416",
+                "movies": [
+                    {
+                        "title":    "Pushpa: The Rise",
+                        "year":     2021,        # int or None
+                        "director": "Sukumar"    # str or None
+                    },
+                    ...
+                ]
+            }
+
+    Raises:
+        ValueError:           if *wikidata_id* is not a valid QID.
+        requests.HTTPError:   on Wikidata API errors.
+        requests.Timeout:     if the SPARQL endpoint is unresponsive.
+    """
+    qid = _validate_qid(wikidata_id)
+    display_name = actor_name.strip() or qid
+
+    query = f"""
+    SELECT ?film ?filmLabel ?releaseYear ?directorLabel WHERE {{
+
+      # ── Films this actor appeared in ──────────────────────────────────────
+      # wd:{qid} ^wdt:P161 ?film  is shorthand for:  ?film wdt:P161 wd:{qid}
+      wd:{qid} ^wdt:P161 ?film .
+
+      # Restrict to theatrical films and their Wikidata subclasses.
+      # This excludes TV episodes, documentaries, web series, etc.
+      ?film wdt:P31/wdt:P279* wd:Q11424 .
+
+      # ── Optional metadata ─────────────────────────────────────────────────
+      OPTIONAL {{
+        ?film wdt:P577 ?releaseDate .
+        BIND(YEAR(?releaseDate) AS ?releaseYear)
+      }}
+      OPTIONAL {{
+        ?film wdt:P57 ?director .
+      }}
+
+      # Resolve labels in English.
+      SERVICE wikibase:label {{
+        bd:serviceParam wikibase:language "en" .
+      }}
+    }}
+    ORDER BY ?releaseYear
+    LIMIT 300
+    """
+
+    print(f"  Querying Wikidata : {display_name} ({qid})")
+    results  = _sparql_query(query)
+    bindings = results.get("results", {}).get("bindings", [])
+
+    # Deduplicate by (title, year) — one row per unique film.
+    seen:   set[tuple]  = set()
+    movies: list[dict]  = []
+
+    for binding in bindings:
+        title        = binding.get("filmLabel",      {}).get("value", "")
+        year_raw     = binding.get("releaseYear",     {}).get("value")
+        director_raw = binding.get("directorLabel",   {}).get("value", "")
+
+        # Drop rows where the label service returned a raw entity ID.
+        if not title or _is_unresolved_qid(title):
+            continue
+
+        year: Optional[int] = int(year_raw) if year_raw else None
+        director: Optional[str] = (
+            director_raw
+            if director_raw and not _is_unresolved_qid(director_raw)
+            else None
+        )
+
+        key = (title, year)
+        if key in seen:
+            continue   # already have this film — skip extra director binding
+        seen.add(key)
+
+        movies.append({"title": title, "year": year, "director": director})
+
+    return {
+        "actor":       display_name,
+        "wikidata_id": qid,
+        "movies":      movies,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Standalone test entry-point
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    # Usage:
+    #   python -m data_pipeline.wikidata_client Q352416
+    #   python -m data_pipeline.wikidata_client Q352416 "Allu Arjun"
+    if len(sys.argv) < 2:
+        print("Usage: python -m data_pipeline.wikidata_client <QID> [actor_name]")
+        print()
+        print("Examples:")
+        print("  python -m data_pipeline.wikidata_client Q352416")
+        print('  python -m data_pipeline.wikidata_client Q352416 "Allu Arjun"')
+        print('  python -m data_pipeline.wikidata_client Q351478 "Rajinikanth"')
+        sys.exit(1)
+
+    _qid  = sys.argv[1]
+    _name = sys.argv[2] if len(sys.argv) > 2 else ""
+    _data = fetch_actor_filmography(_qid, _name)
+    print(json.dumps(_data, indent=2, ensure_ascii=False))

--- a/backend/data_pipeline/wikipedia_client.py
+++ b/backend/data_pipeline/wikipedia_client.py
@@ -1,0 +1,518 @@
+"""
+wikipedia_client.py
+===================
+Fetches film metadata from the public English Wikipedia MediaWiki API and
+parses the structured film infobox to extract:
+  - runtime           (int, minutes)
+  - production_company (str, first listed company)
+  - language          (str, first listed language)
+
+Sprint 4 additions
+------------------
+  HTTP caching (Task 3):
+    requests-cache is used to avoid re-fetching Wikipedia pages that were
+    already retrieved in a previous run.  Pages are cached for 24 hours in
+    a local SQLite file named ``wiki_cache.sqlite``.  On a re-run of
+    enrich_movies.py the cache is consulted first; only cache misses generate
+    real HTTP calls, dramatically speeding up subsequent enrichment passes.
+
+  Retry logic (Task 4):
+    A ``urllib3.util.retry.Retry`` strategy is mounted on the session with:
+      - 3 total retries
+      - Exponential backoff: 1 s → 2 s → 4 s between attempts
+      - Retries on HTTP 429 (rate limited), 500, 502, 503, 504
+    Transient network blips or Wikipedia rate-limit bursts are handled
+    transparently without any changes to calling code.
+
+Design rules (unchanged):
+  - One public function:  fetch_movie_metadata(title) -> dict
+  - Every HTTP call goes through _get(), which enforces a 1-second delay and
+    a descriptive User-Agent so Wikipedia can identify and contact us.
+  - On *any* error (network, parse, missing data) the function returns a dict
+    with None values rather than raising — the pipeline must never crash on a
+    single bad page.
+  - Two HTTP calls per movie: one search call, one parse call.
+
+Requires:
+  pip install requests beautifulsoup4 requests-cache
+
+Usage (standalone test):
+    python -m data_pipeline.wikipedia_client "Pushpa: The Rise"
+    python -m data_pipeline.wikipedia_client "Baahubali: The Beginning"
+"""
+
+import json
+import re
+import sys
+import time
+from typing import Optional
+
+import requests_cache
+from bs4 import BeautifulSoup, Tag
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+WIKI_API_URL = "https://en.wikipedia.org/w/api.php"
+
+# Polite rate limit: every live HTTP call sleeps this many seconds first.
+# Cached responses do NOT sleep (they are served from disk instantly).
+REQUEST_DELAY: float = 1.0
+
+# Cache settings
+CACHE_NAME = "wiki_cache"        # SQLite file: wiki_cache.sqlite (in CWD)
+CACHE_EXPIRE = 86_400            # 24 hours — Wikipedia film pages are stable
+
+# Wikipedia's bot policy requires a meaningful User-Agent.
+USER_AGENT = (
+    "SouthCinemaAnalytics/1.0 "
+    "(https://github.com/south-cinema-analytics; "
+    "contact@south-cinema-analytics.example) "
+    "Python/3.11 requests-cache/beautifulsoup4"
+)
+
+_HEADERS = {
+    "User-Agent": USER_AGENT,
+    "Accept": "application/json",
+}
+
+# Infobox row labels we care about (lowercased for case-insensitive matching).
+_RUNTIME_LABELS    = {"running time", "runtime"}
+_PRODUCTION_LABELS = {"production company", "production companies"}
+_LANGUAGE_LABELS   = {"language", "languages"}
+
+# Empty result returned whenever metadata cannot be found.
+_EMPTY: dict = {"runtime": None, "production_company": None, "language": None}
+
+
+# ---------------------------------------------------------------------------
+# Session: caching + retry (Task 3 & Task 4)
+# ---------------------------------------------------------------------------
+
+def _build_session() -> requests_cache.CachedSession:
+    """
+    Create a requests session with:
+      - 24-hour SQLite cache (requests-cache)
+      - Automatic retry on transient errors (urllib3 Retry)
+
+    The CachedSession is a drop-in replacement for requests.Session.
+    Cached responses are returned immediately without touching the network,
+    so REQUEST_DELAY is only applied for real (un-cached) HTTP calls.
+
+    Returns:
+        Configured CachedSession instance.
+    """
+    session = requests_cache.CachedSession(
+        CACHE_NAME,
+        expire_after=CACHE_EXPIRE,
+        # Cache only successful (2xx) responses.
+        allowable_codes=[200],
+        # Cache GET requests only.
+        allowable_methods=["GET"],
+        # Thread-safe SQLite backend (uses WAL mode internally).
+        backend="sqlite",
+    )
+
+    # Retry strategy: 3 attempts with exponential backoff.
+    # Delays: 1 s, 2 s, 4 s (backoff_factor=1 → factor * (2^attempt)).
+    retry = Retry(
+        total=3,
+        backoff_factor=1,
+        status_forcelist=[429, 500, 502, 503, 504],
+        raise_on_status=False,  # let raise_for_status() in _get() handle it
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("https://", adapter)
+    session.mount("http://",  adapter)
+
+    return session
+
+
+# Module-level session: shared across all calls within a process.
+# Thread-safe: each thread gets its own SQLite connection via the cache backend.
+_SESSION: requests_cache.CachedSession = _build_session()
+
+
+# ---------------------------------------------------------------------------
+# Internal HTTP helper
+# ---------------------------------------------------------------------------
+
+def _get(params: dict) -> dict:
+    """
+    Rate-limited GET request to the Wikipedia MediaWiki API.
+
+    Cached responses are served from disk without any delay.
+    Live (un-cached) requests sleep REQUEST_DELAY seconds before sending so
+    that repeated cache misses respect Wikipedia's rate-limit guidelines.
+
+    Args:
+        params: Query-string parameters for the MediaWiki API.
+
+    Returns:
+        Parsed JSON response dict.
+
+    Raises:
+        requests.HTTPError: on 4xx / 5xx status codes (after retries are
+                            exhausted for eligible codes).
+        requests.Timeout:   if the server doesn't respond within 30 s.
+    """
+    # Only sleep for real (live) requests; skip delay for cache hits.
+    # We probe the cache before sending to decide whether to sleep.
+    cached_response = _SESSION.cache.get_response(
+        _SESSION.prepare_request(
+            requests_cache.AnyRequest(  # type: ignore[attr-defined]
+                "GET", WIKI_API_URL, params=params
+            )
+        )
+    ) if hasattr(_SESSION, "cache") else None
+
+    if cached_response is None:
+        # Live request — sleep to respect rate limit.
+        time.sleep(REQUEST_DELAY)
+
+    response = _SESSION.get(
+        WIKI_API_URL,
+        params=params,
+        headers=_HEADERS,
+        timeout=30,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+# ---------------------------------------------------------------------------
+# Step 1 — Search for the Wikipedia page
+# ---------------------------------------------------------------------------
+
+def _search_page_id(movie_title: str) -> Optional[int]:
+    """
+    Search Wikipedia full-text for the most relevant film article and return
+    its numeric page ID.
+
+    Appending " film" to the query biases results toward film articles and
+    away from disambiguation pages or unrelated uses of the title.
+
+    We inspect up to 5 results and prefer any result whose title contains
+    the original movie title (case-insensitive).  If none match, we fall
+    back to the first result.
+
+    Args:
+        movie_title: Film title as stored in the DB, e.g. "Pushpa: The Rise".
+
+    Returns:
+        Integer Wikipedia page ID, or None if the search found nothing.
+    """
+    params = {
+        "action":   "query",
+        "list":     "search",
+        "srsearch": f"{movie_title} film",
+        "srlimit":  5,
+        "srinfo":   "",           # suppress extra metadata we don't need
+        "srprop":   "titlesnippet",
+        "format":   "json",
+    }
+
+    try:
+        data    = _get(params)
+        results = data.get("query", {}).get("search", [])
+    except Exception:
+        return None
+
+    if not results:
+        return None
+
+    # Prefer a result whose title contains the original query (minus colons,
+    # dashes etc.) — helps with titles like "Pushpa: The Rise – Part 1".
+    normalised = movie_title.lower().split(":")[0].strip()
+    for result in results:
+        if normalised in result["title"].lower():
+            return result["pageid"]
+
+    # Fall back to the top search result.
+    return results[0]["pageid"]
+
+
+# ---------------------------------------------------------------------------
+# Step 2 — Fetch and parse the page HTML
+# ---------------------------------------------------------------------------
+
+def _fetch_page_html(page_id: int) -> Optional[str]:
+    """
+    Fetch the fully rendered HTML of a Wikipedia page by its page ID.
+
+    We use action=parse rather than action=query+prop=revisions so that
+    Wikipedia renders all templates (including the infobox) into HTML before
+    we receive it — no need to parse raw wikitext.
+
+    Args:
+        page_id: Integer Wikipedia page ID from _search_page_id().
+
+    Returns:
+        HTML string of the page body, or None on any error.
+    """
+    params = {
+        "action": "parse",
+        "pageid": page_id,
+        "prop":   "text",
+        "format": "json",
+    }
+
+    try:
+        data = _get(params)
+        return data.get("parse", {}).get("text", {}).get("*")
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Infobox parsing helpers
+# ---------------------------------------------------------------------------
+
+def _clean_cell(td: Tag) -> str:
+    """
+    Extract readable text from a table data cell (<td>), stripping:
+      - Superscript citations ([1], [2] …)
+      - Invisible spans used for sorting (e.g. <span style="display:none">)
+      - Excess whitespace
+
+    We also normalise internal newlines / <br> tags to spaces so that
+    multi-line values (e.g. lists of companies) become a single string
+    that we can then split on commas or newlines.
+
+    Args:
+        td: BeautifulSoup Tag object for the <td> element.
+
+    Returns:
+        Cleaned plain-text string.
+    """
+    # Work on a copy so we don't mutate the shared parse tree.
+    cell = BeautifulSoup(str(td), "html.parser")
+
+    # Drop citation superscripts: <sup class="reference">…</sup>
+    for sup in cell.find_all("sup"):
+        sup.decompose()
+
+    # Drop hidden sorting spans.
+    for span in cell.find_all("span", style=lambda s: s and "display:none" in s):
+        span.decompose()
+
+    # Replace <br> and <li> boundaries with a sentinel we can split on later.
+    for tag in cell.find_all(["br", "li"]):
+        tag.replace_with("\n")
+
+    text = cell.get_text(separator=" ")
+
+    # Collapse runs of whitespace (spaces, tabs) but keep newlines.
+    text = re.sub(r"[ \t]+", " ", text)
+    # Remove leading/trailing whitespace from each logical line.
+    lines = [line.strip() for line in text.splitlines()]
+    # Drop empty lines.
+    lines = [line for line in lines if line]
+
+    return "\n".join(lines)
+
+
+def _first_non_empty(values: list[str]) -> Optional[str]:
+    """Return the first non-empty, non-whitespace string, or None."""
+    for v in values:
+        v = v.strip()
+        if v:
+            return v
+    return None
+
+
+def _parse_runtime_text(text: str) -> Optional[int]:
+    """
+    Convert a runtime text fragment into an integer number of minutes.
+
+    Handles the common Wikipedia formats:
+      "179 minutes"              →  179
+      "179"                      →  179
+      "2 hours 59 minutes"       →  179
+      "2 hours"                  →  120
+      "2 hr 59 min"              →  179
+      "179 min"                  →  179
+
+    Args:
+        text: Raw text value from the "Running time" infobox row.
+
+    Returns:
+        Integer minutes, or None if the format is not recognised.
+    """
+    text = text.strip()
+
+    # "X hours Y minutes" or "X hr Y min" variants.
+    m = re.search(
+        r"(\d+)\s*h(?:ours?|r)?\s*(\d+)\s*m(?:inutes?|in)?",
+        text,
+        re.IGNORECASE,
+    )
+    if m:
+        return int(m.group(1)) * 60 + int(m.group(2))
+
+    # "X hours" (no minutes component).
+    m = re.search(r"(\d+)\s*h(?:ours?|r)?", text, re.IGNORECASE)
+    if m:
+        return int(m.group(1)) * 60
+
+    # "X minutes" or "X min".
+    m = re.search(r"(\d+)\s*m(?:inutes?|in)?", text, re.IGNORECASE)
+    if m:
+        return int(m.group(1))
+
+    # Bare integer (e.g. just "179").
+    m = re.fullmatch(r"\d+", text)
+    if m:
+        return int(text)
+
+    return None
+
+
+def _split_list_value(text: str) -> list[str]:
+    """
+    Split a multi-valued infobox cell (e.g. a list of companies or languages)
+    into individual cleaned items.
+
+    Splits on newlines (already inserted by _clean_cell for <br>/<li>) and
+    on commas, then strips each token.
+
+    Args:
+        text: Multi-line / comma-separated text from _clean_cell().
+
+    Returns:
+        List of non-empty stripped strings.
+    """
+    # Split on newlines first (already our primary separator from _clean_cell).
+    parts: list[str] = []
+    for segment in text.splitlines():
+        # Further split by comma within each line.
+        for item in segment.split(","):
+            item = item.strip()
+            if item:
+                parts.append(item)
+    return parts
+
+
+# ---------------------------------------------------------------------------
+# Main infobox parser
+# ---------------------------------------------------------------------------
+
+def _parse_infobox(html: str) -> dict:
+    """
+    Parse the film infobox from a rendered Wikipedia page HTML string.
+
+    Wikipedia film infoboxes are HTML <table> elements whose class list
+    contains "infobox".  Each row has a <th> label and a <td> value.
+    We build a label → value map and pick out the three fields we need.
+
+    Args:
+        html: Full HTML string of the Wikipedia page body.
+
+    Returns:
+        Dict with keys runtime (int|None), production_company (str|None),
+        language (str|None).
+    """
+    result: dict = dict(_EMPTY)   # start with all-None copy
+
+    soup = BeautifulSoup(html, "html.parser")
+
+    # Locate the infobox table (class contains "infobox").
+    infobox: Optional[Tag] = soup.find(
+        "table",
+        class_=lambda c: c and "infobox" in c.split(),
+    )
+    if infobox is None:
+        return result   # page exists but has no infobox (e.g. redirect target)
+
+    for row in infobox.find_all("tr"):
+        th: Optional[Tag] = row.find("th")
+        td: Optional[Tag] = row.find("td")
+        if not th or not td:
+            continue
+
+        label = th.get_text(separator=" ", strip=True).lower()
+        value = _clean_cell(td)
+
+        # ── Runtime ──────────────────────────────────────────────────────────
+        if result["runtime"] is None and label in _RUNTIME_LABELS:
+            # Use only the first line (some pages add clarifications after).
+            first_line = value.splitlines()[0] if value else ""
+            parsed = _parse_runtime_text(first_line)
+            if parsed is None and value:
+                # Try parsing the whole text in case there's no newline.
+                parsed = _parse_runtime_text(value)
+            result["runtime"] = parsed
+
+        # ── Production company ───────────────────────────────────────────────
+        elif result["production_company"] is None and label in _PRODUCTION_LABELS:
+            companies = _split_list_value(value)
+            result["production_company"] = _first_non_empty(companies)
+
+        # ── Language ─────────────────────────────────────────────────────────
+        elif result["language"] is None and label in _LANGUAGE_LABELS:
+            langs = _split_list_value(value)
+            result["language"] = _first_non_empty(langs)
+
+        # Stop early once all three fields are populated.
+        if all(v is not None for v in result.values()):
+            break
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def fetch_movie_metadata(title: str) -> dict:
+    """
+    Fetch Wikipedia metadata for a single film.
+
+    Makes at most two HTTP calls (search + parse), each subject to the
+    REQUEST_DELAY rate limit.  Cached responses are served from disk
+    instantly without sleeping.  Returns a dict with None values on any
+    failure so that callers never need to guard against exceptions.
+
+    Args:
+        title: Film title as stored in the movies table, e.g. "Pushpa: The Rise".
+
+    Returns:
+        {
+            "runtime":            179,                    # int minutes, or None
+            "production_company": "Mythri Movie Makers",  # str or None
+            "language":           "Telugu",               # str or None
+        }
+
+    Example:
+        >>> meta = fetch_movie_metadata("Pushpa: The Rise")
+        >>> meta["runtime"]
+        179
+        >>> meta["language"]
+        'Telugu'
+    """
+    # Step 1 — Find the Wikipedia page.
+    page_id = _search_page_id(title)
+    if page_id is None:
+        return dict(_EMPTY)
+
+    # Step 2 — Fetch and parse its infobox.
+    html = _fetch_page_html(page_id)
+    if html is None:
+        return dict(_EMPTY)
+
+    return _parse_infobox(html)
+
+
+# ---------------------------------------------------------------------------
+# Standalone test entry-point
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    _title = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else "Pushpa: The Rise"
+    print(f"Fetching metadata for: {_title!r}")
+    _meta = fetch_movie_metadata(_title)
+    print(json.dumps(_meta, indent=2, ensure_ascii=False))

--- a/backend/migrations/sprint2_add_directors.sql
+++ b/backend/migrations/sprint2_add_directors.sql
@@ -1,0 +1,109 @@
+-- =============================================================================
+-- Migration: Sprint 2 — Add normalized director tables
+-- File     : backend/migrations/sprint2_add_directors.sql
+-- Target   : PostgreSQL (tested on PG 14+)
+--
+-- What this migration does:
+--   1. Creates the `directors` table (one row per unique director).
+--   2. Creates the `movie_directors` join table (movie ↔ director, many-to-many).
+--   3. Backfills data from the existing movies.director TEXT column so that
+--      historical seed data becomes queryable via the new normalized tables.
+--   4. Does NOT remove movies.director — that column stays for backward compat.
+--
+-- Safe to re-run: every statement uses IF NOT EXISTS / ON CONFLICT DO NOTHING.
+-- =============================================================================
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- 1. directors
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS directors (
+    id   SERIAL       PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    CONSTRAINT uq_directors_name UNIQUE (name)
+);
+
+-- Explicit index on id mirrors SQLAlchemy's index=True on the PK column.
+CREATE INDEX IF NOT EXISTS ix_directors_id   ON directors (id);
+-- Explicit index on name speeds up the frequent lookup-by-name upsert.
+CREATE INDEX IF NOT EXISTS ix_directors_name ON directors (name);
+
+COMMENT ON TABLE  directors      IS 'Normalized director entities (Sprint 2).';
+COMMENT ON COLUMN directors.name IS 'Full English name, e.g. "Sukumar". Unique.';
+
+
+-- ---------------------------------------------------------------------------
+-- 2. movie_directors  (join table)
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS movie_directors (
+    movie_id    INTEGER NOT NULL
+                    REFERENCES movies(id)    ON DELETE CASCADE ON UPDATE CASCADE,
+    director_id INTEGER NOT NULL
+                    REFERENCES directors(id) ON DELETE CASCADE ON UPDATE CASCADE,
+    PRIMARY KEY (movie_id, director_id)   -- composite PK = uniqueness constraint
+);
+
+-- Individual indexes on FKs for efficient reverse lookups:
+--   "find all movies by director X"  →  ix_movie_directors_director_id
+--   "find all directors of movie Y"  →  covered by the PK index on movie_id
+CREATE INDEX IF NOT EXISTS ix_movie_directors_director_id
+    ON movie_directors (director_id);
+
+COMMENT ON TABLE  movie_directors             IS 'Movie ↔ Director join table (Sprint 2).';
+COMMENT ON COLUMN movie_directors.movie_id    IS 'FK → movies.id';
+COMMENT ON COLUMN movie_directors.director_id IS 'FK → directors.id';
+
+
+-- ---------------------------------------------------------------------------
+-- 3. Backfill from movies.director TEXT column
+--
+-- For every movie that already has a non-empty director string, we:
+--   a) Insert the director name into `directors` (skip duplicates).
+--   b) Insert the (movie_id, director_id) link into `movie_directors` (skip dupes).
+--
+-- This ensures existing seed data is immediately queryable via the new tables.
+-- ---------------------------------------------------------------------------
+
+-- 3a. Seed directors from the legacy text column.
+INSERT INTO directors (name)
+SELECT DISTINCT TRIM(director)          -- deduplicate and strip whitespace
+FROM   movies
+WHERE  director IS NOT NULL
+  AND  TRIM(director) <> ''
+ON CONFLICT (name) DO NOTHING;          -- idempotent: skip if already exists
+
+-- 3b. Seed movie_directors join rows.
+INSERT INTO movie_directors (movie_id, director_id)
+SELECT m.id,
+       d.id
+FROM   movies    m
+JOIN   directors d ON d.name = TRIM(m.director)
+WHERE  m.director IS NOT NULL
+  AND  TRIM(m.director) <> ''
+ON CONFLICT DO NOTHING;                 -- idempotent: skip existing (movie_id, director_id) pairs
+
+
+-- ---------------------------------------------------------------------------
+-- 4. Verification queries  (comment out in production; uncomment to inspect)
+-- ---------------------------------------------------------------------------
+
+-- Check newly created directors:
+-- SELECT * FROM directors ORDER BY name;
+
+-- Check movie → director links:
+-- SELECT m.title, m.release_year, d.name AS director
+-- FROM   movie_directors md
+-- JOIN   movies    m ON m.id = md.movie_id
+-- JOIN   directors d ON d.id = md.director_id
+-- ORDER  BY m.release_year DESC, m.title;
+
+-- Count summary:
+-- SELECT
+--     (SELECT COUNT(*) FROM directors)     AS total_directors,
+--     (SELECT COUNT(*) FROM movie_directors) AS total_links;
+
+
+COMMIT;

--- a/backend/migrations/sprint3_add_actor_registry.sql
+++ b/backend/migrations/sprint3_add_actor_registry.sql
@@ -1,0 +1,97 @@
+-- =============================================================================
+-- Migration: Sprint 3 — Add actor_registry table
+-- File     : backend/migrations/sprint3_add_actor_registry.sql
+-- Target   : PostgreSQL (tested on PG 14+)
+--
+-- What this migration does:
+--   1. Creates the actor_registry table (one row per actor we want to ingest).
+--   2. Inserts 13 South Indian actors with their Wikidata QIDs.
+--
+-- QID verification:
+--   Every QID below links to the actor's canonical Wikidata page.
+--   Verify before running in production:
+--       https://www.wikidata.org/wiki/<QID>
+--   Example:  https://www.wikidata.org/wiki/Q352416  →  Allu Arjun
+--
+-- Safe to re-run: CREATE TABLE uses IF NOT EXISTS, INSERT uses ON CONFLICT DO NOTHING.
+-- =============================================================================
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- 1. Create actor_registry table
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS actor_registry (
+    id          SERIAL       PRIMARY KEY,
+    name        VARCHAR(255) NOT NULL,
+    wikidata_id VARCHAR(20)  NOT NULL,
+    industry    VARCHAR(100) NOT NULL,
+    CONSTRAINT uq_actor_registry_wikidata_id UNIQUE (wikidata_id)
+);
+
+CREATE INDEX IF NOT EXISTS ix_actor_registry_id          ON actor_registry (id);
+CREATE INDEX IF NOT EXISTS ix_actor_registry_wikidata_id ON actor_registry (wikidata_id);
+CREATE INDEX IF NOT EXISTS ix_actor_registry_industry    ON actor_registry (industry);
+
+COMMENT ON TABLE  actor_registry             IS 'Catalog of actors for Wikidata ingestion (Sprint 3).';
+COMMENT ON COLUMN actor_registry.wikidata_id IS 'Canonical Wikidata QID, e.g. Q352416. Unique per actor.';
+COMMENT ON COLUMN actor_registry.industry    IS 'Film industry label used for new movie rows, e.g. Telugu.';
+
+
+-- ---------------------------------------------------------------------------
+-- 2. Insert initial actor data
+--
+-- QID verification URLs (open in browser to confirm):
+--   Telugu actors:
+--     Allu Arjun   → https://www.wikidata.org/wiki/Q352416
+--     Mahesh Babu  → https://www.wikidata.org/wiki/Q1373503
+--     Prabhas      → https://www.wikidata.org/wiki/Q297491
+--     Ram Charan   → https://www.wikidata.org/wiki/Q3419703
+--     Jr. NTR      → https://www.wikidata.org/wiki/Q942132
+--     Pawan Kalyan → https://www.wikidata.org/wiki/Q469302
+--   Tamil actors:
+--     Vijay        → https://www.wikidata.org/wiki/Q536725
+--     Ajith Kumar  → https://www.wikidata.org/wiki/Q535632
+--     Suriya       → https://www.wikidata.org/wiki/Q1365617
+--     Dhanush      → https://www.wikidata.org/wiki/Q560524
+--     Karthi       → https://www.wikidata.org/wiki/Q1163208
+--     Rajinikanth  → https://www.wikidata.org/wiki/Q351478
+--     Kamal Haasan → https://www.wikidata.org/wiki/Q330829
+-- ---------------------------------------------------------------------------
+
+INSERT INTO actor_registry (name, wikidata_id, industry) VALUES
+
+    -- ── Telugu ───────────────────────────────────────────────────────────────
+    ('Allu Arjun',          'Q352416',  'Telugu'),   -- https://www.wikidata.org/wiki/Q352416
+    ('Mahesh Babu',         'Q1373503', 'Telugu'),   -- https://www.wikidata.org/wiki/Q1373503
+    ('Prabhas',             'Q297491',  'Telugu'),   -- https://www.wikidata.org/wiki/Q297491
+    ('Ram Charan',          'Q3419703', 'Telugu'),   -- https://www.wikidata.org/wiki/Q3419703
+    ('N. T. Rama Rao Jr.',  'Q942132',  'Telugu'),   -- https://www.wikidata.org/wiki/Q942132
+    ('Pawan Kalyan',        'Q469302',  'Telugu'),   -- https://www.wikidata.org/wiki/Q469302
+
+    -- ── Tamil ────────────────────────────────────────────────────────────────
+    ('Vijay',               'Q536725',  'Tamil'),    -- https://www.wikidata.org/wiki/Q536725
+    ('Ajith Kumar',         'Q535632',  'Tamil'),    -- https://www.wikidata.org/wiki/Q535632
+    ('Suriya',              'Q1365617', 'Tamil'),    -- https://www.wikidata.org/wiki/Q1365617
+    ('Dhanush',             'Q560524',  'Tamil'),    -- https://www.wikidata.org/wiki/Q560524
+    ('Karthi',              'Q1163208', 'Tamil'),    -- https://www.wikidata.org/wiki/Q1163208
+    ('Rajinikanth',         'Q351478',  'Tamil'),    -- https://www.wikidata.org/wiki/Q351478
+    ('Kamal Haasan',        'Q330829',  'Tamil')     -- https://www.wikidata.org/wiki/Q330829
+
+ON CONFLICT (wikidata_id) DO NOTHING;    -- idempotent: skip if QID already exists
+
+
+-- ---------------------------------------------------------------------------
+-- 3. Verification
+-- ---------------------------------------------------------------------------
+
+-- Quick sanity check (uncomment to inspect):
+-- SELECT id, name, wikidata_id, industry FROM actor_registry ORDER BY industry, name;
+
+-- Expected output: 13 rows (6 Telugu, 7 Tamil).
+-- SELECT COUNT(*) FROM actor_registry;
+-- SELECT industry, COUNT(*) FROM actor_registry GROUP BY industry ORDER BY industry;
+
+
+COMMIT;

--- a/backend/migrations/sprint4_indexes_and_constraints.sql
+++ b/backend/migrations/sprint4_indexes_and_constraints.sql
@@ -1,0 +1,136 @@
+-- =============================================================================
+-- Migration: Sprint 4 — Performance indexes and unique constraints
+-- File     : backend/migrations/sprint4_indexes_and_constraints.sql
+-- Target   : PostgreSQL 14+
+--
+-- What this migration does:
+--   Task 1. Adds covering indexes for the most common join/filter paths.
+--   Task 2. Adds UNIQUE constraints to prevent accidental duplicate rows.
+--
+-- Safe to re-run:
+--   All CREATE INDEX statements use IF NOT EXISTS.
+--   UNIQUE constraint additions use DO $$ ... $$ blocks with existence checks.
+--
+-- Run order:
+--   Apply AFTER sprint3_add_actor_registry.sql.
+--   BEFORE running ingest_all_actors or enrich_movies (the unique_movie
+--   constraint requires zero duplicate rows — verified at migration time).
+-- =============================================================================
+
+BEGIN;
+
+
+-- ---------------------------------------------------------------------------
+-- TASK 1 — Performance indexes
+-- ---------------------------------------------------------------------------
+
+-- ── movies(title, release_year) ──────────────────────────────────────────────
+-- The most common lookup key used by _get_or_create_movie() and analytics
+-- queries.  A composite index means the DB can satisfy both WHERE and ORDER BY
+-- from index pages without touching the heap for these two columns.
+CREATE INDEX IF NOT EXISTS idx_movies_title_year
+    ON movies (title, release_year);
+
+-- ── cast(actor_id) ───────────────────────────────────────────────────────────
+-- "All movies of actor X" — used by the actor filmography API and the
+-- actor_film_counts materialized view refresh.
+CREATE INDEX IF NOT EXISTS idx_cast_actor
+    ON "cast" (actor_id);
+
+-- ── cast(movie_id) ───────────────────────────────────────────────────────────
+-- "All actors in movie Y" — used by cast-listing endpoints.
+CREATE INDEX IF NOT EXISTS idx_cast_movie
+    ON "cast" (movie_id);
+
+-- ── actor_registry(wikidata_id) ──────────────────────────────────────────────
+-- Queried on every ingestion run to resolve QIDs.
+-- Note: uq_actor_registry_wikidata_id already provides a unique B-tree index;
+-- this named index is added for API consistency.  IF NOT EXISTS prevents a
+-- duplicate-index error if the index already exists under this name.
+CREATE INDEX IF NOT EXISTS idx_actor_registry_qid
+    ON actor_registry (wikidata_id);
+
+
+-- ---------------------------------------------------------------------------
+-- TASK 2 — Unique constraints
+-- ---------------------------------------------------------------------------
+
+-- ── movies: UNIQUE(title, release_year) ──────────────────────────────────────
+-- Prevents the ingestion pipeline from creating duplicate movie rows.
+-- The DO block first verifies no existing duplicates, then conditionally adds
+-- the constraint so the migration is safe to re-run.
+DO $$
+BEGIN
+    -- Safety guard: abort if duplicates already exist.
+    IF EXISTS (
+        SELECT 1
+        FROM   movies
+        GROUP  BY title, release_year
+        HAVING COUNT(*) > 1
+    ) THEN
+        RAISE EXCEPTION
+            'Cannot add UNIQUE(title, release_year): duplicate rows exist. '
+            'Run: SELECT title, release_year, COUNT(*) FROM movies '
+            'GROUP BY title, release_year HAVING COUNT(*) > 1;';
+    END IF;
+
+    -- Add the constraint only if it isn't already present.
+    IF NOT EXISTS (
+        SELECT 1
+        FROM   pg_constraint
+        WHERE  conname    = 'unique_movie'
+        AND    conrelid   = 'movies'::regclass
+    ) THEN
+        ALTER TABLE movies
+            ADD CONSTRAINT unique_movie UNIQUE (title, release_year);
+        RAISE NOTICE 'Added constraint unique_movie on movies(title, release_year).';
+    ELSE
+        RAISE NOTICE 'Constraint unique_movie already exists — skipped.';
+    END IF;
+END
+$$;
+
+-- ── actor_registry: UNIQUE(wikidata_id) ──────────────────────────────────────
+-- The Sprint 3 migration already created uq_actor_registry_wikidata_id.
+-- This block adds the canonical alias name unique_actor_qid only if neither
+-- that nor any other unique constraint on wikidata_id exists yet.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM   pg_constraint
+        WHERE  conname  = 'unique_actor_qid'
+        AND    conrelid = 'actor_registry'::regclass
+    ) THEN
+        -- Only add if wikidata_id is not already covered by a unique constraint.
+        -- (uq_actor_registry_wikidata_id from Sprint 3 already covers it.)
+        -- We intentionally skip re-adding if an equivalent constraint exists.
+        RAISE NOTICE
+            'unique_actor_qid not added: wikidata_id already has constraint '
+            'uq_actor_registry_wikidata_id from sprint3_add_actor_registry.sql.';
+    ELSE
+        RAISE NOTICE 'Constraint unique_actor_qid already exists — skipped.';
+    END IF;
+END
+$$;
+
+
+-- ---------------------------------------------------------------------------
+-- Verification queries (uncomment to inspect)
+-- ---------------------------------------------------------------------------
+
+-- Check all new indexes are present:
+-- SELECT indexname, indexdef
+-- FROM   pg_indexes
+-- WHERE  tablename IN ('movies', 'cast', 'actor_registry')
+-- AND    indexname IN ('idx_movies_title_year','idx_cast_actor',
+--                      'idx_cast_movie','idx_actor_registry_qid')
+-- ORDER BY indexname;
+
+-- Check unique_movie constraint:
+-- SELECT conname, contype
+-- FROM   pg_constraint
+-- WHERE  conrelid = 'movies'::regclass AND contype = 'u';
+
+
+COMMIT;

--- a/backend/migrations/sprint4_materialized_views.sql
+++ b/backend/migrations/sprint4_materialized_views.sql
@@ -1,0 +1,114 @@
+-- =============================================================================
+-- Migration: Sprint 4 — Analytics materialized views
+-- File     : backend/migrations/sprint4_materialized_views.sql
+-- Target   : PostgreSQL 14+
+--
+-- What this migration does:
+--   Creates two pre-computed materialized views that eliminate heavy
+--   multi-table joins for the most common analytics queries.
+--
+-- Performance impact:
+--   Without views → every analytics request JOINs actors + cast + movies
+--   With views    → a single indexed scan of a small pre-computed table
+--   Typical speedup: 10–100× depending on dataset size
+--
+-- Refresh strategy:
+--   Materialized views are NOT updated automatically.  Run:
+--       python -m data_pipeline.refresh_analytics_views
+--   after every Wikidata ingestion or Wikipedia enrichment run.
+--
+-- Safe to re-run:
+--   CREATE MATERIALIZED VIEW uses IF NOT EXISTS.
+--   DROP + RECREATE is NOT used — existing data is preserved until refresh.
+-- =============================================================================
+
+BEGIN;
+
+
+-- ---------------------------------------------------------------------------
+-- View 1: actor_film_counts
+-- ---------------------------------------------------------------------------
+-- Powers: "Top actors by film count" leaderboard, actor profile pages.
+-- Replaces the slow live query:
+--   SELECT a.name, COUNT(c.movie_id) FROM actors a JOIN cast c ON ... GROUP BY ...
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS actor_film_counts AS
+SELECT
+    a.id          AS actor_id,
+    a.name        AS actor_name,
+    a.industry    AS industry,
+    COUNT(c.movie_id) AS film_count
+FROM   actors a
+JOIN   "cast" c ON a.id = c.actor_id
+GROUP  BY a.id, a.name, a.industry
+WITH   DATA;    -- populate immediately on creation
+
+-- Unique index on actor_id allows REFRESH MATERIALIZED VIEW CONCURRENTLY
+-- (non-blocking refresh while queries continue reading the old data).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_actor_film_counts_actor_id
+    ON actor_film_counts (actor_id);
+
+-- Supporting index for the most common filter/sort patterns.
+CREATE INDEX IF NOT EXISTS idx_actor_film_counts_industry
+    ON actor_film_counts (industry);
+
+CREATE INDEX IF NOT EXISTS idx_actor_film_counts_film_count
+    ON actor_film_counts (film_count DESC);
+
+COMMENT ON MATERIALIZED VIEW actor_film_counts IS
+    'Pre-computed actor film counts. Refresh after ingestion via refresh_analytics_views.py.';
+
+
+-- ---------------------------------------------------------------------------
+-- View 2: actor_director_collaborations
+-- ---------------------------------------------------------------------------
+-- Powers: "Director collaboration" charts, "who works with whom" analytics.
+-- Replaces the live query:
+--   SELECT a.name, m.director, COUNT(*) FROM cast c
+--   JOIN actors a ON ... JOIN movies m ON ... WHERE m.director IS NOT NULL GROUP BY ...
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS actor_director_collaborations AS
+SELECT
+    a.name        AS actor,
+    a.industry    AS industry,
+    m.director    AS director,
+    COUNT(*)      AS collaborations
+FROM   "cast" c
+JOIN   actors a ON a.id  = c.actor_id
+JOIN   movies m ON m.id  = c.movie_id
+WHERE  m.director IS NOT NULL
+GROUP  BY a.name, a.industry, m.director
+WITH   DATA;
+
+-- Support ORDER BY collaborations DESC efficiently.
+CREATE INDEX IF NOT EXISTS idx_actor_dir_collab_actor
+    ON actor_director_collaborations (actor);
+
+CREATE INDEX IF NOT EXISTS idx_actor_dir_collab_director
+    ON actor_director_collaborations (director);
+
+CREATE INDEX IF NOT EXISTS idx_actor_dir_collab_count
+    ON actor_director_collaborations (collaborations DESC);
+
+COMMENT ON MATERIALIZED VIEW actor_director_collaborations IS
+    'Pre-computed actor-director collaboration counts. Refresh after ingestion.';
+
+
+-- ---------------------------------------------------------------------------
+-- Verification (uncomment to inspect immediately after migration)
+-- ---------------------------------------------------------------------------
+
+-- Top 5 actors by film count:
+-- SELECT actor_name, industry, film_count
+-- FROM   actor_film_counts
+-- ORDER  BY film_count DESC
+-- LIMIT  5;
+
+-- Most frequent collaborations:
+-- SELECT actor, director, collaborations
+-- FROM   actor_director_collaborations
+-- ORDER  BY collaborations DESC
+-- LIMIT  10;
+
+
+COMMIT;

--- a/backend/migrations/sprint4_pipeline_runs.sql
+++ b/backend/migrations/sprint4_pipeline_runs.sql
@@ -1,0 +1,74 @@
+-- =============================================================================
+-- Migration: Sprint 4 — Pipeline run tracking table
+-- File     : backend/migrations/sprint4_pipeline_runs.sql
+-- Target   : PostgreSQL 14+
+--
+-- What this migration does:
+--   Creates the pipeline_runs table that records every execution of the
+--   Wikidata ingestion and Wikipedia enrichment pipelines.
+--
+-- Why a separate table?
+--   Provides an audit trail for debugging, performance monitoring, and
+--   understanding when data was last refreshed without adding noise to the
+--   core cinema schema.
+--
+-- Safe to re-run: CREATE TABLE uses IF NOT EXISTS.
+-- =============================================================================
+
+BEGIN;
+
+
+-- ---------------------------------------------------------------------------
+-- Create pipeline_runs table
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS pipeline_runs (
+    id          SERIAL       PRIMARY KEY,
+
+    -- What kind of run: "wikidata_ingestion" or "wikipedia_enrichment"
+    run_type    VARCHAR(100) NOT NULL,
+
+    -- Wall-clock start/finish timestamps (with timezone).
+    started_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    finished_at TIMESTAMPTZ,           -- NULL while still running
+
+    -- Terminal state: "running" → "success" | "failed"
+    status      VARCHAR(20)  NOT NULL DEFAULT 'running'
+                             CHECK (status IN ('running', 'success', 'failed')),
+
+    -- Optional JSON blob with per-run statistics.
+    -- Example for wikidata_ingestion:
+    --   {"actors": 13, "films_found": 759, "inserted": 2, "skipped": 757}
+    -- Example for wikipedia_enrichment:
+    --   {"processed": 50, "updated": 18, "skipped": 30, "errors": 2}
+    details     TEXT
+);
+
+-- Indexes for the most common query patterns.
+CREATE INDEX IF NOT EXISTS ix_pipeline_runs_run_type
+    ON pipeline_runs (run_type);
+
+CREATE INDEX IF NOT EXISTS ix_pipeline_runs_started_at
+    ON pipeline_runs (started_at DESC);
+
+CREATE INDEX IF NOT EXISTS ix_pipeline_runs_status
+    ON pipeline_runs (status);
+
+-- Table / column documentation.
+COMMENT ON TABLE  pipeline_runs            IS 'Audit log of data pipeline executions (Sprint 4).';
+COMMENT ON COLUMN pipeline_runs.run_type   IS 'One of: wikidata_ingestion, wikipedia_enrichment.';
+COMMENT ON COLUMN pipeline_runs.status     IS 'Lifecycle state: running → success | failed.';
+COMMENT ON COLUMN pipeline_runs.details    IS 'JSON string with per-run statistics.';
+
+
+-- ---------------------------------------------------------------------------
+-- Verification (uncomment to inspect after migration)
+-- ---------------------------------------------------------------------------
+
+-- SELECT column_name, data_type, is_nullable, column_default
+-- FROM   information_schema.columns
+-- WHERE  table_name = 'pipeline_runs'
+-- ORDER  BY ordinal_position;
+
+
+COMMIT;

--- a/backend/migrations/sprint5_analytics_tables.sql
+++ b/backend/migrations/sprint5_analytics_tables.sql
@@ -1,0 +1,157 @@
+-- =============================================================================
+-- Migration: Sprint 5 — Precomputed analytics tables
+-- File     : backend/migrations/sprint5_analytics_tables.sql
+-- Target   : PostgreSQL 14+
+--
+-- What this migration does:
+--   Task 1. Creates four denormalised analytics tables that store precomputed
+--           aggregates, eliminating expensive multi-table joins at query time.
+--   Task 2. Adds covering indexes so every analytics lookup is an index scan.
+--
+-- Design notes:
+--   • These tables are populated (and refreshed) entirely by:
+--       python -m data_pipeline.build_analytics_tables
+--     They are NEVER written to by the ingestion pipeline; they are read-only
+--     from the application's perspective.
+--
+--   • actor_id columns are plain INTs (no FOREIGN KEY constraint).
+--     Denormalised analytics tables intentionally omit FK constraints so
+--     TRUNCATE + re-INSERT can run without disabling triggers.
+--
+--   • actor_collaborations stores BOTH directions (A→B and B→A) so dashboard
+--     queries can use a simple WHERE actor1_id = ? without needing an OR.
+--
+-- Safe to re-run: all CREATE TABLE / CREATE INDEX use IF NOT EXISTS.
+--
+-- Run order: after sprint4_*.sql migrations.
+-- =============================================================================
+
+BEGIN;
+
+
+-- ---------------------------------------------------------------------------
+-- Table 1: actor_stats
+-- ---------------------------------------------------------------------------
+-- One row per actor — precomputed career summary.
+-- Answers: "How many films has Rajinikanth made? When was his first film?"
+
+CREATE TABLE IF NOT EXISTS actor_stats (
+    actor_id        INT     PRIMARY KEY,            -- maps to actors.id
+    film_count      INT     NOT NULL DEFAULT 0,     -- total distinct films
+    first_film_year INT,                            -- earliest release_year (>0)
+    last_film_year  INT,                            -- latest  release_year (>0)
+    avg_runtime     FLOAT                           -- average runtime in minutes
+);
+
+COMMENT ON TABLE  actor_stats              IS 'Precomputed career stats per actor. Rebuilt by build_analytics_tables.py.';
+COMMENT ON COLUMN actor_stats.first_film_year IS 'Excludes sentinel year 0 (used when year is unknown).';
+COMMENT ON COLUMN actor_stats.avg_runtime     IS 'NULL if no enriched movies exist yet for this actor.';
+
+
+-- ---------------------------------------------------------------------------
+-- Table 2: actor_collaborations
+-- ---------------------------------------------------------------------------
+-- One row per ordered (actor1, actor2) pair — how often they share a film.
+-- Both directions stored: (A,B) AND (B,A) with the same count.
+-- Answers: "How many films did Prabhas and Ram Charan do together?"
+
+CREATE TABLE IF NOT EXISTS actor_collaborations (
+    actor1_id          INT NOT NULL,    -- maps to actors.id
+    actor2_id          INT NOT NULL,    -- maps to actors.id  (actor1_id != actor2_id)
+    collaboration_count INT NOT NULL DEFAULT 0,
+    PRIMARY KEY (actor1_id, actor2_id)
+);
+
+COMMENT ON TABLE actor_collaborations IS
+    'Precomputed co-occurrence counts. Both directions (A→B and B→A) are stored.';
+
+
+-- ---------------------------------------------------------------------------
+-- Table 3: actor_director_stats
+-- ---------------------------------------------------------------------------
+-- One row per (actor, director) pair — how many films they made together.
+-- Sourced from movies.director (the legacy denormalised TEXT column).
+-- Answers: "How many films did Prabhas do with S.S. Rajamouli?"
+
+CREATE TABLE IF NOT EXISTS actor_director_stats (
+    actor_id   INT  NOT NULL,    -- maps to actors.id
+    director   TEXT NOT NULL,    -- director name from movies.director
+    film_count INT  NOT NULL DEFAULT 0,
+    PRIMARY KEY (actor_id, director)
+);
+
+COMMENT ON TABLE actor_director_stats IS
+    'Precomputed actor-director collaboration counts from movies.director.';
+
+
+-- ---------------------------------------------------------------------------
+-- Table 4: actor_production_stats
+-- ---------------------------------------------------------------------------
+-- One row per (actor, production_company) pair — how many films together.
+-- Sourced from movies.production_company (populated by Wikipedia enrichment).
+-- Answers: "How many films did Vijay do under Sun Pictures?"
+
+CREATE TABLE IF NOT EXISTS actor_production_stats (
+    actor_id           INT  NOT NULL,    -- maps to actors.id
+    production_company TEXT NOT NULL,   -- from movies.production_company
+    film_count         INT  NOT NULL DEFAULT 0,
+    PRIMARY KEY (actor_id, production_company)
+);
+
+COMMENT ON TABLE actor_production_stats IS
+    'Precomputed actor-production-company collaboration counts.';
+
+
+-- ---------------------------------------------------------------------------
+-- Task 2 — Indexes
+-- ---------------------------------------------------------------------------
+-- The composite PKs already cover (actor_id, …) prefix lookups.
+-- These single-column indexes support queries that filter on actor_id alone,
+-- and help the query planner choose index scans over sequential scans.
+
+-- actor_stats: PK is actor_id; this index is for explicit O(1) lookup.
+CREATE INDEX IF NOT EXISTS idx_actor_stats_actor
+    ON actor_stats (actor_id);
+
+-- actor_collaborations: PK is (actor1_id, actor2_id).
+-- Single-column index on actor1_id lets us list all collaborators of one actor.
+CREATE INDEX IF NOT EXISTS idx_collab_actor1
+    ON actor_collaborations (actor1_id);
+
+-- actor_director_stats: PK is (actor_id, director).
+-- Filter by actor_id to get all directors an actor worked with.
+CREATE INDEX IF NOT EXISTS idx_director_actor
+    ON actor_director_stats (actor_id);
+
+-- actor_production_stats: PK is (actor_id, production_company).
+-- Filter by actor_id to get all production companies an actor worked with.
+CREATE INDEX IF NOT EXISTS idx_production_actor
+    ON actor_production_stats (actor_id);
+
+-- Additional reverse-direction index: "which actors worked with director X?"
+CREATE INDEX IF NOT EXISTS idx_director_name
+    ON actor_director_stats (director);
+
+-- Additional reverse-direction index: "which actors worked with company X?"
+CREATE INDEX IF NOT EXISTS idx_production_company
+    ON actor_production_stats (production_company);
+
+
+-- ---------------------------------------------------------------------------
+-- Verification (uncomment to inspect after migration)
+-- ---------------------------------------------------------------------------
+
+-- Confirm tables were created:
+-- SELECT tablename FROM pg_tables
+-- WHERE tablename IN ('actor_stats','actor_collaborations',
+--                     'actor_director_stats','actor_production_stats')
+-- ORDER BY tablename;
+
+-- Confirm indexes were created:
+-- SELECT indexname, indexdef FROM pg_indexes
+-- WHERE tablename IN ('actor_stats','actor_collaborations',
+--                     'actor_director_stats','actor_production_stats')
+-- ORDER BY tablename, indexname;
+
+
+COMMIT;

--- a/backend/migrations/sprint6_indexes.sql
+++ b/backend/migrations/sprint6_indexes.sql
@@ -1,0 +1,106 @@
+-- =============================================================================
+-- Migration: Sprint 6 — API Performance Indexes
+-- File     : backend/migrations/sprint6_indexes.sql
+-- Target   : PostgreSQL 14+
+--
+-- What this migration does:
+--   Adds the remaining indexes required for the analytics API layer
+--   introduced in Sprint 6. All indexes use IF NOT EXISTS so the file
+--   is safe to re-run without error.
+--
+-- Context — indexes already in place from earlier sprints:
+--   Sprint 4 (sprint4_indexes_and_constraints.sql):
+--     idx_movies_title_year         ON movies(title, release_year)
+--     idx_cast_actor                ON "cast"(actor_id)
+--     idx_cast_movie                ON "cast"(movie_id)
+--     idx_actor_registry_qid        ON actor_registry(wikidata_id)
+--   Sprint 5 (sprint5_analytics_tables.sql):
+--     idx_actor_stats_actor         ON actor_stats(actor_id)
+--     idx_collab_actor1             ON actor_collaborations(actor1_id)
+--     idx_director_actor            ON actor_director_stats(actor_id)
+--     idx_production_actor          ON actor_production_stats(actor_id)
+--     idx_director_name             ON actor_director_stats(director)
+--     idx_production_company        ON actor_production_stats(production_company)
+--
+-- New indexes added here:
+--   idx_movies_title                ON movies(title)
+--       Speeds up title-only lookups independently of release_year.
+--       The compound idx_movies_title_year is still preferred when both
+--       columns appear in the query; this index serves title-only plans.
+--
+--   idx_collab_actor2               ON actor_collaborations(actor2_id)
+--       Enables efficient "who has actor X appeared with?" reverse lookups.
+--       Although the bidirectional storage means actor1_id queries cover
+--       most cases, this index future-proofs reverse-direction analytics.
+--
+--   idx_actors_name_lower           ON actors(lower(name))
+--       Functional index on the lowercased name for case-insensitive exact
+--       matches (used by the /compare and search endpoints internally).
+--       Note: ILIKE '%fragment%' with a leading wildcard cannot use a
+--       btree index regardless — sequential scan is fine for 13 actors.
+--
+-- Run order: after sprint5_*.sql migrations.
+-- =============================================================================
+
+BEGIN;
+
+
+-- ---------------------------------------------------------------------------
+-- movies(title) — standalone title index
+-- ---------------------------------------------------------------------------
+-- The Sprint 4 compound index (title, release_year) covers title-prefix
+-- queries. This standalone index makes title-only predicates explicit and
+-- easy for the query planner to choose.
+
+CREATE INDEX IF NOT EXISTS idx_movies_title
+    ON movies (title);
+
+COMMENT ON INDEX idx_movies_title IS
+    'Standalone title index for title-only lookups (Sprint 6).';
+
+
+-- ---------------------------------------------------------------------------
+-- actor_collaborations(actor2_id) — reverse-direction lookup index
+-- ---------------------------------------------------------------------------
+-- Composite PK is (actor1_id, actor2_id); that PK index only helps when
+-- filtering by actor1_id first. This index covers the reverse direction:
+-- "find all rows where a specific actor appears as actor2".
+
+CREATE INDEX IF NOT EXISTS idx_collab_actor2
+    ON actor_collaborations (actor2_id);
+
+COMMENT ON INDEX idx_collab_actor2 IS
+    'Reverse-direction index on actor_collaborations for actor2 lookups (Sprint 6).';
+
+
+-- ---------------------------------------------------------------------------
+-- actors(lower(name)) — case-insensitive name lookup index
+-- ---------------------------------------------------------------------------
+-- actors.name already has a UNIQUE btree index (created by SQLAlchemy).
+-- This functional index on lower(name) accelerates the pattern:
+--   WHERE lower(actors.name) = lower(:name)
+-- used by the /compare endpoint and get_actor_by_name().
+
+CREATE INDEX IF NOT EXISTS idx_actors_name_lower
+    ON actors (lower(name));
+
+COMMENT ON INDEX idx_actors_name_lower IS
+    'Functional index for case-insensitive exact name lookups (Sprint 6).';
+
+
+-- ---------------------------------------------------------------------------
+-- Verification queries (uncomment to confirm after applying)
+-- ---------------------------------------------------------------------------
+
+-- List all sprint6 indexes:
+-- SELECT indexname, indexdef
+-- FROM   pg_indexes
+-- WHERE  indexname IN (
+--            'idx_movies_title',
+--            'idx_collab_actor2',
+--            'idx_actors_name_lower'
+--        )
+-- ORDER  BY indexname;
+
+
+COMMIT;

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,9 @@ uvicorn
 sqlalchemy
 psycopg2-binary
 pydantic
+requests
+beautifulsoup4
+# Sprint 4: HTTP caching for Wikipedia enrichment (Task 3)
+requests-cache
+# Sprint 4: Retry / backoff already bundled in urllib3 (pulled in by requests)
+# urllib3 is a transitive dependency — no explicit pin needed.


### PR DESCRIPTION
Data pipeline (Sprints 2-5):
- Wikidata SPARQL batch ingestion for 13 South Indian actors (734 movies)
- Wikipedia enrichment for runtime, production company, language
- Precomputed analytics tables: actor_stats, actor_collaborations, actor_director_stats, actor_production_stats
- Pipeline run tracking (pipeline_runs audit log)
- Materialized views: actor_film_counts, actor_director_collaborations
- Retry logic (urllib3) + HTTP caching (requests-cache) on all clients
- Parallel Wikipedia enrichment via ThreadPoolExecutor

Migrations (Sprints 2-6):
- sprint2_add_directors.sql: normalized directors + movie_directors tables
- sprint3_add_actor_registry.sql: Wikidata QID seed catalog
- sprint4_indexes_and_constraints.sql: performance indexes + unique constraints
- sprint4_pipeline_runs.sql: pipeline audit log table
- sprint4_materialized_views.sql: actor_film_counts, actor_director_collaborations
- sprint5_analytics_tables.sql: 4 precomputed analytics tables + indexes
- sprint6_indexes.sql: API-layer indexes (title, actor2_id, lower(name))

API layer (Sprint 6):
- GET /health — live actor + movie counts
- GET /actors/search?q= — case-insensitive partial match, max 20 results
- GET /actors — list all actors
- GET /actors/{id} — profile from precomputed actor_stats (O(1))
- GET /actors/{id}/movies — filmography ordered newest-first
- GET /actors/{id}/collaborators — top co-stars from actor_collaborations
- GET /actors/{id}/directors — director stats from actor_director_stats
- GET /actors/{id}/production — studio stats from actor_production_stats
- GET /compare?actor1=&actor2= — side-by-side from actor_stats (O(1))
- Full OpenAPI docs at /docs and /redoc

## What does this PR do?
-

## Why is this change needed?
-

## Screenshots / Output (if UI)
-

## Checklist
- [ ] Builds locally (or via Docker)
- [ ] No breaking DB changes without discussion
- [ ] Small, focused PR
