### PR TITLE
feat(sprint-26): homepage redesign + WOW insight engine v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,20 @@
 # South Cinema Analytics
 
-An analytics platform for South Indian cinema. Ingests filmography data from Wikidata and Wikipedia, precomputes actor statistics, and exposes a FastAPI REST API for a dashboard frontend to consume.
+A cinema curiosity engine for South Indian films. Explore the collaboration networks, career arcs, and box-office records of actors across Telugu, Tamil, Malayalam, and Kannada cinema.
+
+**Dataset:** ~10,000+ movies · 6,700+ actors · 4 industries
 
 ---
 
 ## What it does
 
-- Pulls complete filmographies for 13 major South Indian actors from **Wikidata** via SPARQL
-- Enriches movie records with runtime, production company, and language from **Wikipedia**
-- Precomputes analytics tables (career stats, collaborations, director pairings) so dashboard queries are O(1)
-- Serves all data through a typed **FastAPI** REST API with interactive docs
-
----
-
-## Actors covered
-
-| Actor | Industry |
-|---|---|
-| Allu Arjun | Telugu |
-| Mahesh Babu | Telugu |
-| Prabhas | Telugu |
-| Ram Charan | Telugu |
-| N. T. Rama Rao Jr. | Telugu |
-| Pawan Kalyan | Telugu |
-| Vijay | Tamil |
-| Ajith Kumar | Tamil |
-| Suriya | Tamil |
-| Dhanush | Tamil |
-| Karthi | Tamil |
-| Rajinikanth | Tamil |
-| Kamal Haasan | Tamil |
-
-**Dataset size:** ~734 movies, ~759 cast links
+- **Connection Finder** — animated BFS shortest path between any two actors through shared films
+- **Cinema Universe** — force-directed collaboration graph of primary actors
+- **Gravity Center** — Brandes betweenness-centrality leaderboard (in-memory, sub-second)
+- **WOW Insights** — story-driven cinema facts (collaboration shock, career peaks, network power, director loyalty) with TTL-cached scoring
+- **Actor Profiles** — filmography, co-stars, director partnerships, production companies
+- **Side-by-side Compare** — career stats from precomputed analytics tables (O(1))
+- **Stats for Nerds** — industry distribution, top partnerships, career timelines, chart builder
 
 ---
 
@@ -39,12 +22,29 @@ An analytics platform for South Indian cinema. Ingests filmography data from Wik
 
 | Layer | Technology |
 |---|---|
-| API | FastAPI + Uvicorn |
+| Frontend | Next.js 14 (App Router) · TypeScript · Tailwind CSS |
+| Backend | FastAPI · Uvicorn |
 | ORM | SQLAlchemy |
 | Database | PostgreSQL 15 |
-| Data sources | Wikidata SPARQL, Wikipedia |
-| HTTP clients | requests, requests-cache (Wikipedia caching) |
-| Retry logic | urllib3 `Retry` (3 retries, backoff) |
+| Containerisation | Docker Compose |
+| Data sources | TMDB API · Wikidata SPARQL · Wikipedia |
+
+---
+
+## Running with Docker
+
+```bash
+docker compose up --build
+```
+
+| Service | URL |
+|---|---|
+| Frontend | http://localhost:3000 |
+| Backend API | http://localhost:8000 |
+| Swagger docs | http://localhost:8000/docs |
+
+The backend connects to Postgres inside the same Compose network.
+The frontend calls the backend at `http://backend:8000` server-side (SSR/RSC) and `http://localhost:8000` client-side (browser).
 
 ---
 
@@ -54,30 +54,144 @@ An analytics platform for South Indian cinema. Ingests filmography data from Wik
 south-cinema-analytics/
 ├── backend/
 │   ├── app/
-│   │   ├── main.py          # FastAPI routes
-│   │   ├── crud.py          # Database query functions
-│   │   ├── models.py        # SQLAlchemy ORM models
-│   │   ├── schemas.py       # Pydantic request/response schemas
-│   │   └── database.py      # DB connection + session factory
+│   │   ├── main.py              # FastAPI app, CORS, lifespan (graph build on startup)
+│   │   ├── crud.py              # All database query functions
+│   │   ├── insight_engine.py    # WOW insight patterns + thread-safe TTL cache
+│   │   ├── models.py            # SQLAlchemy ORM models
+│   │   ├── schemas.py           # Pydantic request / response schemas
+│   │   └── database.py          # DB engine + session factory
 │   ├── data_pipeline/
-│   │   ├── ingest_all_actors.py        # Wikidata batch ingestion
-│   │   ├── ingest_actor.py             # Per-actor upsert logic
-│   │   ├── enrich_movies.py            # Wikipedia enrichment
-│   │   ├── build_analytics_tables.py   # Precompute analytics tables
-│   │   ├── refresh_analytics_views.py  # Refresh materialized views
-│   │   ├── wikidata_client.py          # Single-actor SPARQL client
-│   │   ├── wikidata_batch_client.py    # Batched SPARQL client (VALUES clause)
-│   │   └── wikipedia_client.py        # Wikipedia scraper with caching
-│   ├── migrations/
-│   │   ├── sprint2_add_directors.sql
-│   │   ├── sprint3_add_actor_registry.sql
-│   │   ├── sprint4_indexes_and_constraints.sql
-│   │   ├── sprint4_pipeline_runs.sql
-│   │   ├── sprint4_materialized_views.sql
-│   │   ├── sprint5_analytics_tables.sql
-│   │   └── sprint6_indexes.sql
+│   │   ├── ingest_all_actors.py          # Wikidata batch ingestion (13 primary actors)
+│   │   ├── ingest_supporting_actors.py   # TMDB supporting actor ingestion
+│   │   ├── ingest_malayalam_actors.py    # TMDB Malayalam actor expansion
+│   │   ├── enrich_movies.py              # Wikipedia runtime / production enrichment
+│   │   ├── enrich_box_office.py          # TMDB box-office revenue enrichment
+│   │   ├── backfill_directors.py         # TMDB director credit backfill
+│   │   ├── build_analytics_tables.py     # Precompute all analytics tables
+│   │   └── classify_directors.py         # Set actor_tier (primary / network / null)
+│   ├── migrations/               # Schema migrations — sprint-tagged SQL files
 │   └── requirements.txt
+├── frontend/
+│   ├── app/
+│   │   ├── layout.tsx            # Root layout, global footer, dark theme (#0a0a0f)
+│   │   ├── page.tsx              # Homepage: Hero, Connection Finder, Graph, Insights
+│   │   ├── actors/[id]/          # Actor profile page
+│   │   ├── compare/              # Side-by-side compare page
+│   │   └── stats/                # Stats for Nerds page
+│   ├── components/
+│   │   ├── HeroSearch.tsx        # Hero search with trending actor chips
+│   │   ├── ConnectionFinder.tsx  # Search form wired to /stats/connection
+│   │   ├── ConnectionResult.tsx  # Animated BFS path replay (step-by-step)
+│   │   ├── GraphPreview.tsx      # Interactive collaboration network graph
+│   │   ├── InsightsCarousel.tsx  # Infinite-scroll WOW insight cards (RAF loop)
+│   │   ├── InsightCard.tsx       # Gradient card — single or paired actor avatars
+│   │   ├── ActorAvatar.tsx       # Avatar image with deterministic initials fallback
+│   │   └── stats/                # Stats page sub-components (charts, panels)
+│   └── lib/
+│       └── api.ts                # Typed fetch helpers for every backend endpoint
+├── docker-compose.yml
 └── README.md
+```
+
+---
+
+## Backend API
+
+Full interactive docs at `/docs` (Swagger UI) and `/redoc`.
+
+### Actors
+
+| Method | Endpoint | Description |
+|---|---|---|
+| GET | `/health` | Service status + live row counts |
+| GET | `/actors` | List actors (`?primary_only=true`, `?gender=M\|F`) |
+| GET | `/actors/search?q=` | Partial name search — max 20 results |
+| GET | `/actors/{id}` | Profile with precomputed career stats |
+| GET | `/actors/{id}/movies` | Filmography, newest-first |
+| GET | `/actors/{id}/collaborators` | Top co-stars by shared film count |
+| GET | `/actors/{id}/directors` | Directors sorted by collaboration count |
+| GET | `/actors/{id}/production` | Production companies by film count |
+| GET | `/actors/{id1}/shared/{id2}` | Films two actors appeared in together |
+| GET | `/compare?actor1=&actor2=` | Side-by-side career comparison |
+
+### Analytics
+
+| Method | Endpoint | Description |
+|---|---|---|
+| GET | `/analytics/insights` | WOW insight cards (`?industry=telugu\|tamil\|…`) |
+| GET | `/analytics/top-collaborations` | Actor pairs by shared film count |
+| GET | `/analytics/directors` | Top directors by film count |
+| GET | `/analytics/production-houses` | Top production companies by film count |
+| GET | `/analytics/top-box-office` | Highest-grossing films in INR crore |
+
+### Stats
+
+| Method | Endpoint | Description |
+|---|---|---|
+| GET | `/stats/overview` | Global counts: movies, actors, links, industries |
+| GET | `/stats/most-connected` | Actors ranked by unique co-star count |
+| GET | `/stats/industry-distribution` | Film counts per industry with per-decade breakdown |
+| GET | `/stats/top-partnerships` | Top actor–director partnerships (≥ 3 films) |
+| GET | `/stats/career-timeline?actor_id=` | Films per year for one actor |
+| GET | `/stats/top-costars` | Highest network-centrality actors |
+| GET | `/stats/connection?actor1_id=&actor2_id=` | BFS shortest collaboration path (in-memory graph) |
+| GET | `/stats/chart-data` | Dynamic chart data for the chart builder |
+| GET | `/stats/cinema-universe` | Force-directed graph: nodes + edges |
+| GET | `/stats/gravity-center` | Brandes betweenness centrality leaderboard |
+
+---
+
+## WOW Insight Engine
+
+`backend/app/insight_engine.py` runs 6 pattern queries on startup and returns the 3 highest-scoring, most diverse insights.
+
+| Pattern | Category | What it surfaces |
+|---|---|---|
+| `collab_shock` | collaboration | A legendary duo whose last shared film was 8+ years ago |
+| `hidden_dominance` | career | A supporting actor with more films than most lead actors |
+| `cross_industry` | industry | A primary actor who worked across 3+ language industries |
+| `career_peak` | career | The densest 5-year window (≥ 35% of an actor's total output) |
+| `network_power` | network | The actor connected to the most unique co-stars |
+| `director_loyalty` | collaboration | An actor who spent ≥ 30% of their career with one director |
+
+**Scoring:** log-scaled magnitude + per-type importance weight + optional rarity bonus.
+**Confidence:** `min(1.0, score / 100)` — normalised 0–1, exposed to the frontend.
+**Cache:** module-level TTL (10 min), protected by `threading.Lock`. Bust with `_invalidate_cache()` after ingestion.
+
+Each insight emits: `type`, `category`, `title`, `value`, `unit`, `actors`, `actor_ids`, `subtext`, `confidence`.
+
+---
+
+## Data pipeline
+
+Run in order after a fresh database:
+
+```bash
+cd backend
+
+# 1. Wikidata — 13 primary South Indian actors
+DATABASE_URL=postgresql://sca:sca@localhost:5432/sca python -m data_pipeline.ingest_all_actors
+
+# 2. TMDB — supporting actors from primary actors' film credits
+DATABASE_URL=postgresql://sca:sca@localhost:5432/sca python -m data_pipeline.ingest_supporting_actors
+
+# 3. TMDB — Malayalam actor expansion
+DATABASE_URL=postgresql://sca:sca@localhost:5432/sca python -m data_pipeline.ingest_malayalam_actors
+
+# 4. Wikipedia — enrich movies with runtime, production company, language
+DATABASE_URL=postgresql://sca:sca@localhost:5432/sca python -m data_pipeline.enrich_movies
+
+# 5. TMDB — backfill director credits
+DATABASE_URL=postgresql://sca:sca@localhost:5432/sca python -m data_pipeline.backfill_directors
+
+# 6. TMDB — box-office revenue (INR crore at 84 INR/USD)
+DATABASE_URL=postgresql://sca:sca@localhost:5432/sca python -m data_pipeline.enrich_box_office
+
+# 7. Classify director-only entries; set actor_tier
+DATABASE_URL=postgresql://sca:sca@localhost:5432/sca python -m data_pipeline.classify_directors
+
+# 8. Build precomputed analytics tables (re-run after any ingestion step)
+DATABASE_URL=postgresql://sca:sca@localhost:5432/sca python -m data_pipeline.build_analytics_tables
 ```
 
 ---
@@ -85,180 +199,70 @@ south-cinema-analytics/
 ## Database schema
 
 ```
-actor_registry          seed catalog — Wikidata QIDs for ingestion
-actors                  ingested actor records
-movies                  ingested film records (enriched by Wikipedia)
-cast                    actor ↔ movie join table (many-to-many)
-directors               normalized director entities
-movie_directors         movie ↔ director join table (many-to-many)
-pipeline_runs           audit log for every pipeline execution
+actors                  actor records — actor_tier: 'primary' | 'network' | null (directors)
+movies                  film records — enriched with runtime, language, box_office_crore
+cast                    actor ↔ movie join (Wikidata pipeline)
+actor_movies            actor ↔ movie join (TMDB pipeline — includes character + role_type)
 
-actor_stats             precomputed: film count, career span, avg runtime
-actor_collaborations    precomputed: co-occurrence counts (bidirectional)
+actor_stats             precomputed: film count, career span, avg runtime per actor
+actor_collaborations    precomputed: co-star pair counts (bidirectional)
 actor_director_stats    precomputed: actor × director film counts
 actor_production_stats  precomputed: actor × production company film counts
+
+actor_registry          seed catalog — Wikidata QIDs for primary actor ingestion
+pipeline_runs           audit log for every pipeline execution
 ```
 
 ---
 
-## Setup
-
-### Prerequisites
-
-- Python 3.11+
-- PostgreSQL 15 running locally on port 5432
-- A database named `sca` with user `sca` / password `sca`
-
-```sql
-CREATE USER sca WITH PASSWORD 'sca';
-CREATE DATABASE sca OWNER sca;
-```
-
-### Install dependencies
+## Local development (without Docker)
 
 ```bash
+# Backend
 cd backend
 pip install -r requirements.txt
+DATABASE_URL=postgresql://sca:sca@localhost:5432/sca uvicorn app.main:app --reload --port 8000
+
+# Frontend (separate terminal)
+cd frontend
+npm install
+NEXT_PUBLIC_API_URL=http://localhost:8000 npm run dev
 ```
 
-### Run all migrations (in order)
+Apply all migrations before the first run:
 
 ```bash
-psql -h localhost -p 5432 -U sca -d sca -f migrations/sprint2_add_directors.sql
-psql -h localhost -p 5432 -U sca -d sca -f migrations/sprint3_add_actor_registry.sql
-psql -h localhost -p 5432 -U sca -d sca -f migrations/sprint4_indexes_and_constraints.sql
-psql -h localhost -p 5432 -U sca -d sca -f migrations/sprint4_pipeline_runs.sql
-psql -h localhost -p 5432 -U sca -d sca -f migrations/sprint4_materialized_views.sql
-psql -h localhost -p 5432 -U sca -d sca -f migrations/sprint5_analytics_tables.sql
-psql -h localhost -p 5432 -U sca -d sca -f migrations/sprint6_indexes.sql
+for f in backend/migrations/sprint*.sql; do
+  psql -h localhost -U sca -d sca -f "$f"
+done
 ```
 
-All migrations use `IF NOT EXISTS` and are safe to re-run.
+All migrations use `IF NOT EXISTS` — safe to re-run.
 
 ---
 
-## Running the data pipeline
+## Sprint history
 
-Run these three commands in order. Each step builds on the previous one.
-
-```bash
-cd backend
-
-# 1. Pull filmographies from Wikidata (all 13 actors in one batched SPARQL query)
-DATABASE_URL=postgresql://sca:sca@localhost:5432/sca python -m data_pipeline.ingest_all_actors
-
-# 2. Enrich movies with runtime, production company, language from Wikipedia
-DATABASE_URL=postgresql://sca:sca@localhost:5432/sca python -m data_pipeline.enrich_movies
-
-# 3. Build precomputed analytics tables (fast O(1) reads for the API)
-DATABASE_URL=postgresql://sca:sca@localhost:5432/sca python -m data_pipeline.build_analytics_tables
-```
-
-### Pipeline options
-
-```bash
-# Ingest only Telugu actors, limit to 50 movies for testing
-python -m data_pipeline.ingest_all_actors --industry Telugu --limit 50
-
-# Dry-run enrichment (no DB writes) with 4 parallel workers
-python -m data_pipeline.enrich_movies --dry-run --workers 4
-
-# Refresh materialized views after ingestion
-python -m data_pipeline.refresh_analytics_views
-```
+| Sprint | What shipped |
+|---|---|
+| 1–6 | Core backend · Wikidata ingestion · analytics tables · actor + compare API |
+| 7–8 | TMDB columns · supporting actor ingestion |
+| 9 | Movie industry field · Malayalam actor expansion |
+| 10 | `/analytics/top-collaborations` |
+| 11 | Next.js 14 frontend: homepage · Header · InsightCard · TrendingActors |
+| 15 | `/analytics/insights` — dynamic insight cards |
+| 19 | `/analytics/directors` · `/analytics/production-houses` |
+| 21 | Stats for Nerds: full `/stats/*` suite |
+| 22 | Cinema Universe graph · Gravity Center (Brandes) · Build Your Own Chart |
+| 23 | Box-office enrichment · `/analytics/top-box-office` |
+| 24 | Gender column · lead actresses · director classification · actor tiers |
+| 25 | Backend refactor: routers / repositories / services · in-memory graph singleton · lifespan startup |
+| 26 | Homepage redesign: HeroSearch · ConnectionFinder + animated path · GraphPreview · InsightsCarousel · WOW insight engine v3 (thread-safe cache · confidence · category field) |
 
 ---
 
-## Starting the API server
+## Data attribution
 
-```bash
-cd backend
-DATABASE_URL=postgresql://sca:sca@localhost:5432/sca python -m uvicorn app.main:app --host 127.0.0.1 --port 8000
-```
-
-- **Swagger UI (interactive):** http://localhost:8000/docs
-- **ReDoc:** http://localhost:8000/redoc
-
----
-
-## API endpoints
-
-| Method | Endpoint | Description |
-|---|---|---|
-| GET | `/health` | Service status + live actor/movie counts |
-| GET | `/actors` | List all actors |
-| GET | `/actors/search?q=` | Case-insensitive partial name search (max 20) |
-| GET | `/actors/{id}` | Actor profile with precomputed career stats |
-| GET | `/actors/{id}/movies` | Filmography ordered newest-first |
-| GET | `/actors/{id}/collaborators` | Top co-stars by shared film count |
-| GET | `/actors/{id}/directors` | Directors sorted by collaboration count |
-| GET | `/actors/{id}/production` | Production companies sorted by film count |
-| GET | `/compare?actor1=&actor2=` | Side-by-side career comparison |
-
-### Example responses
-
-**GET /health**
-```json
-{ "status": "ok", "actors": 13, "movies": 734 }
-```
-
-**GET /actors/search?q=raj**
-```json
-[{ "id": 11, "name": "Rajinikanth" }]
-```
-
-**GET /actors/11**
-```json
-{
-  "id": 11,
-  "name": "Rajinikanth",
-  "industry": "Tamil",
-  "film_count": 157,
-  "first_film_year": 1957,
-  "last_film_year": 2025,
-  "avg_runtime": 170.0
-}
-```
-
-**GET /actors/11/collaborators**
-```json
-[
-  { "actor": "Kamal Haasan", "films": 12 },
-  { "actor": "Prabhas", "films": 1 }
-]
-```
-
-**GET /actors/11/directors**
-```json
-[
-  { "director": "S. P. Muthuraman", "films": 23 },
-  { "director": "R. Thyagarajan", "films": 10 }
-]
-```
-
-**GET /compare?actor1=Rajinikanth&actor2=Kamal Haasan**
-```json
-{
-  "actor1": { "name": "Rajinikanth", "films": 157, "avg_runtime": 170.0, "first_film": 1957, "last_film": 2025 },
-  "actor2": { "name": "Kamal Haasan", "films": 174, "avg_runtime": 182.0, "first_film": 1957, "last_film": 2024 }
-}
-```
-
----
-
-## Performance
-
-All analytics endpoints read from precomputed tables — no heavy joins at request time.
-
-| Endpoint | Strategy | Typical response |
-|---|---|---|
-| `/actors/{id}` | PK lookup on `actor_stats` | < 5 ms |
-| `/actors/{id}/collaborators` | Index scan on `actor_collaborations` | < 5 ms |
-| `/actors/{id}/directors` | Index scan on `actor_director_stats` | < 5 ms |
-| `/compare` | Two PK lookups on `actor_stats` | < 5 ms |
-| `/actors/{id}/movies` | Index join `cast` → `movies` | < 20 ms |
-
-Rebuild analytics tables after any ingestion run:
-```bash
-python -m data_pipeline.build_analytics_tables
-```
+Movie metadata provided by [The Movie Database (TMDB)](https://www.themoviedb.org/).
+This product uses the TMDB API but is not endorsed or certified by TMDB.
+Additional data from [Wikidata](https://www.wikidata.org/) and [Wikipedia](https://www.wikipedia.org/).

--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -346,163 +346,24 @@ def get_top_collaborations(db: Session, limit: int = 20) -> list:
 
 def get_insights(db: Session, industry: Optional[str] = None) -> list:
     """
-    Build a mixed list of 8 dynamic cinema insight objects for the homepage.
+    Return WOW insight cards for the homepage.
 
-    Runs three independent queries and interleaves the results so the response
-    always has a variety of insight types:
+    Delegates entirely to insight_engine.get_wow_insights(), which runs six
+    story-driven patterns (collaboration shock, hidden dominance, cross-industry
+    reach, career peak window, network power, director loyalty) and returns the
+    top 3 diverse, high-impact insights.
 
-    1. Collaboration insights — actor pairs with the most shared films,
-       sourced from the precomputed actor_collaborations table.  The
-       ``actor1_id < actor2_id`` guard picks one canonical direction per pair.
-
-    2. Director partnership insights — actor + director duos with the highest
-       co-film counts, computed from actor_movies ⋈ movies.
-
-    3. Supporting actor insights — the most prolific supporting performers,
-       computed from actor_movies rows where role_type = 'supporting'.
-
-    Parameters
-    ----------
-    industry : Optional industry filter (e.g. "telugu", "tamil").  Pass None
-               or "all" for the cross-industry global view.  Matching is
-               case-insensitive against the actors.industry column.
-               When a specific industry is selected the director HAVING
-               threshold is relaxed from 4 → 2 to ensure results even for
-               smaller industries (e.g. Kannada).
-
-    Interleaving strategy
-    ---------------------
-    Zip the three lists together (collab, director, supporting, collab, …)
-    and take the first 8 entries.  With 5 rows per query this yields
-    3 collaborations + 3 directors + 2 supporting = 8 total, guaranteeing
-    a balanced mix without hardcoding per-type limits.
+    The ``industry`` parameter is accepted for API compatibility but the WOW
+    engine intentionally operates on the full cross-industry dataset — the most
+    surprising insights emerge from unexpected connections across languages.
 
     Returns
     -------
     list of plain dicts — converted to Insight Pydantic models in the route.
+    Empty list triggers the frontend's static fallback cards.
     """
-    from itertools import zip_longest
-
-    # Normalise: None / "all" / "explore" → no filter
-    ind = (
-        industry.lower()
-        if industry and industry.lower() not in ("all", "explore")
-        else None
-    )
-
-    # Relax thresholds for industry-specific views so smaller industries
-    # (Kannada, etc.) still return results.
-    dir_threshold  = 2  if ind else 4   # director co-film minimum
-    supp_threshold = 5  if ind else 10  # supporting actor minimum films
-    # 10+ globally means a genuinely prolific character actor (e.g. Brahmanandam
-    # with 58 films, Nassar with 79).  5+ for a single industry is still
-    # meaningful without letting 1- or 2-film cameos pollute the cards.
-
-    # ── Query 1: Top actor-actor collaborations ──────────────────────────────
-    collab_rows = db.execute(text("""
-        SELECT
-            a1.name                AS actor1,
-            a2.name                AS actor2,
-            a1.id                  AS actor1_id,
-            a2.id                  AS actor2_id,
-            ac.collaboration_count
-        FROM   actor_collaborations ac
-        JOIN   actors a1 ON ac.actor1_id = a1.id
-        JOIN   actors a2 ON ac.actor2_id = a2.id
-        WHERE  ac.actor1_id < ac.actor2_id
-          AND  (:ind IS NULL OR LOWER(a1.industry) = :ind)
-          AND  (:ind IS NULL OR LOWER(a2.industry) = :ind)
-        ORDER  BY ac.collaboration_count DESC
-        LIMIT  5
-    """), {"ind": ind}).fetchall()
-
-    collab_insights = [
-        {
-            "type":      "collaboration",
-            "headline":  f"{row.actor1} and {row.actor2} have appeared together in",
-            "value":     row.collaboration_count,
-            "unit":      "films",
-            "actors":    [row.actor1, row.actor2],
-            "actor_ids": [row.actor1_id, row.actor2_id],
-        }
-        for row in collab_rows
-    ]
-
-    # ── Query 2: Actor-director partnerships ─────────────────────────────────
-    director_rows = db.execute(text("""
-        SELECT
-            a.name       AS actor,
-            a.id         AS actor_id,
-            m.director,
-            COUNT(*)     AS films
-        FROM   actor_movies am
-        JOIN   actors  a ON am.actor_id  = a.id
-        JOIN   movies  m ON am.movie_id  = m.id
-        WHERE  m.director IS NOT NULL
-          AND  m.director <> ''
-          AND  (:ind IS NULL OR LOWER(a.industry) = :ind)
-        GROUP  BY a.name, a.id, m.director
-        HAVING COUNT(*) >= :threshold
-        ORDER  BY films DESC
-        LIMIT  5
-    """), {"ind": ind, "threshold": dir_threshold}).fetchall()
-
-    director_insights = [
-        {
-            "type":      "director",
-            "headline":  f"{row.actor}'s most frequent director is",
-            "value":     row.films,
-            "unit":      "films",
-            "actors":    [row.actor, row.director],
-            # Director is not in the actors table — only the actor's ID is returned
-            "actor_ids": [row.actor_id],
-        }
-        for row in director_rows
-    ]
-
-    # ── Query 3: Prolific supporting actors ──────────────────────────────────
-    # Minimum threshold keeps low-count cameos (1–9 films) off the homepage.
-    # The HAVING guard is the key quality gate:
-    #   - globally:          10+ films  →  genuinely prolific character actor
-    #   - industry-specific:  5+ films  →  meaningful within a smaller pool
-    supporting_rows = db.execute(text("""
-        SELECT
-            a.name,
-            a.id,
-            COUNT(*) AS films
-        FROM   actor_movies am
-        JOIN   actors a ON am.actor_id = a.id
-        WHERE  am.role_type = 'supporting'
-          AND  (:ind IS NULL OR LOWER(a.industry) = :ind)
-        GROUP  BY a.name, a.id
-        HAVING COUNT(*) >= :supp_threshold
-        ORDER  BY films DESC
-        LIMIT  5
-    """), {"ind": ind, "supp_threshold": supp_threshold}).fetchall()
-
-    supporting_insights = [
-        {
-            "type":      "supporting",
-            "headline":  f"A defining face in South Indian cinema, {row.name} has appeared in",
-            "value":     row.films,
-            "unit":      "films",
-            "actors":    [row.name],
-            "actor_ids": [row.id],
-        }
-        for row in supporting_rows
-    ]
-
-    # ── Interleave and cap at 8 ───────────────────────────────────────────────
-    interleaved: list = []
-    for c, d, s in zip_longest(collab_insights, director_insights, supporting_insights):
-        if c:
-            interleaved.append(c)
-        if d:
-            interleaved.append(d)
-        if s:
-            interleaved.append(s)
-
-    return interleaved[:8]
+    from .insight_engine import get_wow_insights
+    return get_wow_insights(db)
 
 
 # ===========================================================================

--- a/backend/app/insight_engine.py
+++ b/backend/app/insight_engine.py
@@ -1,0 +1,543 @@
+"""
+insight_engine.py — WOW Insight Engine for South Cinema Analytics
+
+Generates surprising, story-driven insights for the homepage.
+Each pattern returns a single insight dict (or None if the condition
+is not met by the current dataset).
+
+The engine collects all candidates, scores them by impact, and
+returns the top 3 diverse insights — at most 1 per type.
+
+Fail-safe: a broken pattern is silently skipped so one bad query
+never crashes the homepage.
+
+v2 additions (backward-compatible):
+  • In-memory TTL cache (10 min) — no DB hit on every request
+  • Weighted log-based scoring — balances large numbers vs rare patterns
+  • confidence field (0–1) — simple score normalisation
+  • Logging — candidates generated, scores, final selection
+
+v3 additions (backward-compatible):
+  • Thread-safe cache — Lock protects reads/writes; compute runs outside lock
+  • Smoother confidence curve — score / 100 instead of score / 50
+  • title field — replaces headline for consistent API contract
+  • category field — "collaboration" | "network" | "career" | "industry"
+"""
+
+import math
+import re
+import time
+from threading import Lock
+from typing import Optional
+
+from sqlalchemy.orm import Session
+from sqlalchemy import text
+
+CURRENT_YEAR = 2026
+
+
+# ── Module-level TTL cache ────────────────────────────────────────────────────
+# Shared across all requests in the same process.  Rebuilt once every 10 min.
+# _cache_lock guards both reads and writes; compute runs OUTSIDE the lock so
+# a slow DB query on cache-miss doesn't block other in-flight requests.
+
+_cache_lock: Lock = Lock()
+_cache_data: Optional[list] = None
+_cache_expiry: float = 0.0
+
+
+# ── Pattern 1: Collaboration Shock ────────────────────────────────────────────
+
+def _collaboration_shock(db: Session) -> Optional[dict]:
+    """
+    A legendary duo that worked together many times but hasn't shared
+    the screen in 8+ years.  The gap is what makes it surprising.
+    """
+    row = db.execute(text("""
+        WITH shared_years AS (
+            -- TMDB pipeline
+            SELECT
+                LEAST(am1.actor_id, am2.actor_id)    AS a1_id,
+                GREATEST(am1.actor_id, am2.actor_id) AS a2_id,
+                MAX(m.release_year)                  AS last_year
+            FROM   actor_movies am1
+            JOIN   actor_movies am2 ON am2.movie_id = am1.movie_id
+                                   AND am2.actor_id != am1.actor_id
+            JOIN   movies m ON m.id = am1.movie_id
+            WHERE  m.release_year IS NOT NULL
+            GROUP  BY LEAST(am1.actor_id, am2.actor_id),
+                      GREATEST(am1.actor_id, am2.actor_id)
+
+            UNION ALL
+
+            -- Wikidata pipeline
+            SELECT
+                LEAST(c1.actor_id, c2.actor_id)    AS a1_id,
+                GREATEST(c1.actor_id, c2.actor_id) AS a2_id,
+                MAX(m.release_year)                AS last_year
+            FROM   cast c1
+            JOIN   cast c2 ON c2.movie_id = c1.movie_id
+                           AND c2.actor_id != c1.actor_id
+            JOIN   movies m ON m.id = c1.movie_id
+            WHERE  m.release_year IS NOT NULL
+            GROUP  BY LEAST(c1.actor_id, c2.actor_id),
+                      GREATEST(c1.actor_id, c2.actor_id)
+        ),
+        best_last AS (
+            SELECT a1_id, a2_id, MAX(last_year) AS last_year
+            FROM   shared_years
+            GROUP  BY a1_id, a2_id
+        )
+        SELECT
+            a1.id   AS actor1_id,
+            a1.name AS actor1_name,
+            a2.id   AS actor2_id,
+            a2.name AS actor2_name,
+            ac.collaboration_count AS films,
+            bl.last_year
+        FROM   actor_collaborations ac
+        JOIN   best_last bl ON bl.a1_id = ac.actor1_id
+                            AND bl.a2_id = ac.actor2_id
+        JOIN   actors a1 ON a1.id = ac.actor1_id
+        JOIN   actors a2 ON a2.id = ac.actor2_id
+        WHERE  ac.actor1_id < ac.actor2_id
+          AND  ac.collaboration_count >= 10
+          AND  bl.last_year <= :cutoff
+        ORDER  BY ac.collaboration_count DESC, bl.last_year ASC
+        LIMIT  1
+    """), {"cutoff": CURRENT_YEAR - 8}).fetchone()
+
+    if not row:
+        return None
+
+    gap = CURRENT_YEAR - row.last_year
+    return {
+        "type":      "collab_shock",
+        "category":  "collaboration",
+        "title":     f"{row.actor1_name} & {row.actor2_name}",
+        "value":     row.films,
+        "unit":      "films together",
+        "actors":    [row.actor1_name, row.actor2_name],
+        "actor_ids": [row.actor1_id, row.actor2_id],
+        "subtext":   (
+            f"Worked together {row.films} times — but haven't shared "
+            f"the screen in {gap}+ years."
+        ),
+    }
+
+
+# ── Pattern 2: Hidden Dominance ───────────────────────────────────────────────
+
+def _hidden_dominance(db: Session) -> Optional[dict]:
+    """
+    A supporting actor whose total film count rivals most lead actors —
+    always in the background, never in the spotlight.
+    """
+    row = db.execute(text("""
+        SELECT
+            a.id,
+            a.name,
+            COUNT(am.movie_id) AS film_count
+        FROM   actors a
+        JOIN   actor_movies am ON am.actor_id = a.id
+        WHERE  am.role_type = 'supporting'
+          AND  a.is_primary_actor = FALSE
+        GROUP  BY a.id, a.name
+        HAVING COUNT(am.movie_id) >= 20
+        ORDER  BY film_count DESC
+        LIMIT  1
+    """)).fetchone()
+
+    if not row:
+        return None
+
+    # Average film count among primary actors for context
+    avg_row = db.execute(text("""
+        SELECT AVG(ast.film_count) AS avg_films
+        FROM   actor_stats ast
+        JOIN   actors a ON a.id = ast.actor_id
+        WHERE  a.is_primary_actor = TRUE
+    """)).fetchone()
+    avg = int(avg_row.avg_films or 0) if avg_row else 0
+
+    return {
+        "type":      "hidden_dominance",
+        "category":  "career",
+        "title":     row.name,
+        "value":     row.film_count,
+        "unit":      "films",
+        "actors":    [row.name],
+        "actor_ids": [row.id],
+        "subtext":   (
+            f"Always in the background — {row.film_count} films, "
+            f"rivalling most lead actors (avg {avg})."
+        ),
+    }
+
+
+# ── Pattern 3: Cross-Industry Reach ──────────────────────────────────────────
+
+def _cross_industry_reach(db: Session) -> Optional[dict]:
+    """
+    A primary actor who crossed language barriers to work in 3+ industries.
+    """
+    row = db.execute(text("""
+        SELECT
+            a.id,
+            a.name,
+            COUNT(DISTINCT LOWER(m.industry))                 AS ind_count,
+            COUNT(DISTINCT am.movie_id)                       AS film_count,
+            STRING_AGG(DISTINCT m.industry, ' · '
+                       ORDER BY m.industry)                   AS industries
+        FROM   actors a
+        JOIN   actor_movies am ON am.actor_id = a.id
+        JOIN   movies m        ON m.id = am.movie_id
+        WHERE  m.industry IS NOT NULL
+          AND  m.industry <> ''
+          AND  a.is_primary_actor = TRUE
+        GROUP  BY a.id, a.name
+        HAVING COUNT(DISTINCT LOWER(m.industry)) >= 3
+        ORDER  BY ind_count DESC, film_count DESC
+        LIMIT  1
+    """)).fetchone()
+
+    if not row:
+        return None
+
+    return {
+        "type":      "cross_industry",
+        "category":  "industry",
+        "title":     row.name,
+        "value":     row.ind_count,
+        "unit":      "industries",
+        "actors":    [row.name],
+        "actor_ids": [row.id],
+        "subtext":   (
+            f"Crossed language barriers across {row.ind_count} industries "
+            f"in {row.film_count}+ films: {row.industries}."
+        ),
+    }
+
+
+# ── Pattern 4: Career Peak Window ────────────────────────────────────────────
+
+def _career_peak_window(db: Session) -> Optional[dict]:
+    """
+    The single densest 5-year window in an actor's career — their golden era —
+    where they accounted for ≥35% of their total output.
+    """
+    row = db.execute(text("""
+        WITH yearly AS (
+            SELECT
+                am.actor_id,
+                m.release_year,
+                COUNT(*)  AS films_in_year
+            FROM   actor_movies am
+            JOIN   movies  m ON m.id = am.movie_id
+            JOIN   actors  a ON a.id = am.actor_id
+            WHERE  m.release_year IS NOT NULL
+              AND  a.is_primary_actor = TRUE
+            GROUP  BY am.actor_id, m.release_year
+        ),
+        windows AS (
+            SELECT
+                y1.actor_id,
+                y1.release_year                          AS win_start,
+                SUM(y2.films_in_year)                    AS win_films
+            FROM   yearly y1
+            JOIN   yearly y2 ON  y2.actor_id    = y1.actor_id
+                              AND y2.release_year BETWEEN y1.release_year
+                                                      AND y1.release_year + 4
+            GROUP  BY y1.actor_id, y1.release_year
+        ),
+        best_window AS (
+            SELECT DISTINCT ON (actor_id)
+                actor_id, win_start, win_films
+            FROM   windows
+            ORDER  BY actor_id, win_films DESC
+        )
+        SELECT
+            a.id, a.name,
+            bw.win_start                                AS peak_start,
+            bw.win_start + 4                            AS peak_end,
+            bw.win_films,
+            ast.film_count                              AS total_films
+        FROM   best_window bw
+        JOIN   actors      a   ON a.id         = bw.actor_id
+        JOIN   actor_stats ast ON ast.actor_id = bw.actor_id
+        WHERE  bw.win_films >= 8
+          AND  bw.win_films::float / NULLIF(ast.film_count, 0) >= 0.35
+        ORDER  BY bw.win_films DESC
+        LIMIT  1
+    """)).fetchone()
+
+    if not row:
+        return None
+
+    return {
+        "type":      "career_peak",
+        "category":  "career",
+        "title":     row.name,
+        "value":     f"{row.peak_start}–{row.peak_end}",   # string range — kept as-is
+        "unit":      "peak years",
+        "actors":    [row.name],
+        "actor_ids": [row.id],
+        "subtext":   (
+            f"{row.win_films} of their {row.total_films} films packed into "
+            f"just 5 years ({row.peak_start}–{row.peak_end}) — their golden era."
+        ),
+    }
+
+
+# ── Pattern 5: Network Power ──────────────────────────────────────────────────
+
+def _network_power(db: Session) -> Optional[dict]:
+    """
+    The actor connected to the most unique co-stars across all industries —
+    the ultimate bridge builder.
+    """
+    row = db.execute(text("""
+        SELECT
+            a.id, a.name,
+            COUNT(DISTINCT ac.actor2_id) AS costar_count,
+            ast.film_count
+        FROM   actors a
+        JOIN   actor_stats          ast ON ast.actor_id = a.id
+        JOIN   actor_collaborations ac  ON ac.actor1_id = a.id
+        WHERE  a.is_primary_actor = TRUE
+        GROUP  BY a.id, a.name, ast.film_count
+        HAVING COUNT(DISTINCT ac.actor2_id) >= 30
+        ORDER  BY costar_count DESC
+        LIMIT  1
+    """)).fetchone()
+
+    if not row:
+        return None
+
+    return {
+        "type":      "network_power",
+        "category":  "network",
+        "title":     row.name,
+        "value":     row.costar_count,
+        "unit":      "connections",
+        "actors":    [row.name],
+        "actor_ids": [row.id],
+        "subtext":   (
+            f"Connected to {row.costar_count} unique actors across all industries "
+            f"— the ultimate bridge builder in South Indian cinema."
+        ),
+    }
+
+
+# ── Pattern 6: Director Loyalty ───────────────────────────────────────────────
+
+def _director_loyalty(db: Session) -> Optional[dict]:
+    """
+    An actor who spent ≥30% of their career with a single director —
+    a defining creative partnership.
+    """
+    row = db.execute(text("""
+        SELECT
+            a.id                                                     AS actor_id,
+            ads.actor_name,
+            ads.director_name,
+            ads.film_count                                           AS dir_films,
+            ast.film_count                                           AS total_films,
+            ROUND(ads.film_count * 100.0 / NULLIF(ast.film_count, 0)) AS pct
+        FROM   actor_director_stats ads
+        JOIN   actor_stats ast ON ast.actor_id = ads.actor_id
+        JOIN   actors      a   ON a.id         = ads.actor_id
+        WHERE  a.is_primary_actor = TRUE
+          AND  ads.film_count >= 8
+          AND  ads.film_count * 100.0 / NULLIF(ast.film_count, 0) >= 30
+        ORDER  BY pct DESC, ads.film_count DESC
+        LIMIT  1
+    """)).fetchone()
+
+    if not row:
+        return None
+
+    return {
+        "type":      "director_loyalty",
+        "category":  "collaboration",
+        "title":     row.actor_name,
+        "value":     row.dir_films,
+        "unit":      f"films with {row.director_name}",
+        "actors":    [row.actor_name],
+        "actor_ids": [row.actor_id],
+        "subtext":   (
+            f"{int(row.pct)}% of their career alongside director "
+            f"{row.director_name} — a defining creative partnership."
+        ),
+    }
+
+
+# ── Scoring helpers ───────────────────────────────────────────────────────────
+
+def _extract_number(value) -> Optional[float]:
+    """
+    Safely pull a numeric value from an insight's 'value' field.
+    Handles int, float, and strings like '2015–2020' (returns first number found).
+    """
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        match = re.search(r'\d+', value)
+        if match:
+            return float(match.group())
+    return None
+
+
+def _score(insight: dict) -> float:
+    """
+    Weighted log-based scoring.
+
+    Formula:
+      base  = log(value + 1) × 10        — magnitude (log-scaled, avoids large-number bias)
+      base += type_weight[type]           — category importance
+      base += 15 if insight has 'rarity'  — bonus for rare patterns
+
+    Returns a float; higher = more impressive / surprising.
+    """
+    base = 0.0
+
+    numeric = _extract_number(insight.get("value"))
+    # Skip year-shaped numbers (≥ 1000) — they are labels, not magnitudes.
+    # e.g. career_peak stores "2010–2015" in value; scoring on the year itself
+    # would inflate its score by ~76 points, drowning out film/costar counts.
+    if numeric is not None and numeric < 1000:
+        base += math.log(numeric + 1) * 10
+
+    # Per-category importance weights
+    type_weight: dict = {
+        # WOW engine types
+        "collab_shock":     20,
+        "network_power":    18,
+        "hidden_dominance": 17,
+        "career_peak":      15,
+        "cross_industry":   15,
+        "director_loyalty": 12,
+        # Legacy types from crud.get_insights() — kept for backward compat
+        "collaboration":    20,
+        "director":         12,
+        "supporting":       15,
+    }
+    base += type_weight.get(insight.get("type", ""), 10)
+
+    # Optional rarity bonus — set insight["rarity"] = True in any pattern to boost it
+    if insight.get("rarity"):
+        base += 15
+
+    return base
+
+
+# ── Diversity picker ──────────────────────────────────────────────────────────
+
+def _pick_diverse(candidates: list, n: int = 3) -> list:
+    """
+    Return top-n insights with at most 1 per type, ranked by score.
+    Attaches 'confidence' (0–1) to each candidate and logs progress.
+    """
+    print(f"[INSIGHT] {len(candidates)} candidates generated")
+
+    # Score every candidate, attach confidence, log
+    scored: list = []
+    for ins in candidates:
+        s = _score(ins)
+        # Divide by 100 (not 50) so confidence stays spread across the 0–1 range
+        # and doesn't saturate prematurely on common high-scoring patterns.
+        ins["confidence"] = round(min(1.0, s / 100), 3)
+        scored.append((s, ins))
+        print(
+            f"[INSIGHT] type={ins['type']:<20} "
+            f"score={s:5.1f}  confidence={ins['confidence']:.3f}  "
+            f"title={ins['title']!r}"
+        )
+
+    # Pick top-N with type diversity
+    seen: set = set()
+    result: list = []
+    for _, insight in sorted(scored, key=lambda x: x[0], reverse=True):
+        if insight["type"] not in seen:
+            seen.add(insight["type"])
+            result.append(insight)
+        if len(result) >= n:
+            break
+
+    print(f"[INSIGHT] selected {len(result)}: {[i['type'] for i in result]}")
+    return result
+
+
+# ── Core computation (no cache) ───────────────────────────────────────────────
+
+def compute_wow_insights(db: Session) -> list:
+    """
+    Run all WOW patterns, score candidates, return top 3 diverse insights.
+
+    Fail-safe: a broken pattern is silently skipped — one bad SQL query
+    must not crash the entire homepage.
+
+    Returns an empty list if no patterns fire (triggers frontend fallback).
+    """
+    patterns = [
+        _collaboration_shock,
+        _hidden_dominance,
+        _cross_industry_reach,
+        _career_peak_window,
+        _network_power,
+        _director_loyalty,
+    ]
+
+    candidates = []
+    for pattern in patterns:
+        try:
+            result = pattern(db)
+            if result:
+                candidates.append(result)
+        except Exception:
+            pass   # one broken pattern must not crash the whole page
+
+    return _pick_diverse(candidates)
+
+
+# ── Public entry point (thread-safe TTL cache) ────────────────────────────────
+
+def get_wow_insights(db: Session) -> list:
+    """
+    Returns top 3 WOW insights, cached for 10 minutes.
+
+    Thread-safety design:
+      1. Check cache under lock — return immediately on hit (no contention).
+      2. Compute OUTSIDE the lock — DB queries don't block other requests.
+      3. Write result under lock — last writer wins (acceptable: results are
+         identical across concurrent cache-miss computations).
+
+    To force a refresh after new data ingestion:
+        from app.insight_engine import _invalidate_cache; _invalidate_cache()
+    """
+    global _cache_data, _cache_expiry
+
+    now = time.time()
+
+    with _cache_lock:
+        if _cache_data is not None and now < _cache_expiry:
+            return _cache_data
+
+    # Compute outside the lock — this is the slow part (6 SQL queries).
+    # Multiple threads may enter here on concurrent cache-miss; that is fine —
+    # the work is idempotent and the last write wins.
+    insights = compute_wow_insights(db)
+
+    with _cache_lock:
+        _cache_data = insights
+        _cache_expiry = now + 600   # 10 minutes
+
+    return insights
+
+
+def _invalidate_cache() -> None:
+    """Force the next call to get_wow_insights() to recompute. Useful after ingestion."""
+    global _cache_data, _cache_expiry
+    with _cache_lock:
+        _cache_data = None
+        _cache_expiry = 0.0

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -14,7 +14,7 @@
 #                GET /analytics/production-houses)
 
 from pydantic import BaseModel
-from typing import Optional, List
+from typing import Optional, List, Union
 
 
 # ===========================================================================
@@ -164,21 +164,26 @@ class Insight(BaseModel):
     Fields
     ------
     type      : category — "collaboration" | "director" | "supporting"
-    headline  : sentence fragment describing the fact (value + unit appended by UI)
-    value     : the numeric stat (film count, collaboration count, etc.)
-    unit      : label for the value — always "films" in Sprint 15
-    actors    : names involved; 2 entries for collaborations/directors, 1 for supporting
+                WOW types: "collab_shock" | "hidden_dominance" | "cross_industry"
+                           | "career_peak" | "network_power" | "director_loyalty"
+    headline  : actor name(s) or descriptive fragment (UI displays prominently)
+    value     : the stat — int for counts, str for ranges (e.g. "2005–2010")
+    unit      : label for the value — "films", "industries", "connections", etc.
+    actors    : names involved; 2 entries for collaborations, 1 for solo insights
     actor_ids : database IDs for the actors in `actors` (same order).
                 For director insights only the actor's ID is included (directors
                 are not in the actors table).  Use these IDs to build compare or
                 actor-profile URLs without name→slug conversion.
+    subtext   : optional WOW story sentence — the surprising context behind the stat.
+                Set by the insight engine; None for legacy insight types.
     """
     type: str
     headline: str
-    value: int
+    value: Union[int, str]   # int for counts; str for ranges like "2005–2010"
     unit: str
     actors: List[str]
     actor_ids: List[int] = []
+    subtext: Optional[str] = None   # WOW story sentence (insight_engine.py)
 
 
 class InsightsOut(BaseModel):

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,23 +1,37 @@
 // Force dynamic rendering so searchParams (?industry=…) is always fresh
-// and never served from the Next.js full-route cache.
 export const dynamic = 'force-dynamic'
 
 import Header from '@/components/Header'
-import NavTabs from '@/components/NavTabs'
-import InsightCard, { InsightCardData } from '@/components/InsightCard'
-import TrendingActors, { TrendingActor } from '@/components/TrendingActors'
-import { getInsights, getActors, getTopBoxOffice, BoxOfficeEntry } from '@/lib/api'
+import HeroSearch from '@/components/HeroSearch'
+import GraphPreview from '@/components/GraphPreview'
+import InsightsCarousel from '@/components/InsightsCarousel'
+import { type InsightCardData } from '@/components/InsightCard'
+import ConnectionFinder from '@/components/stats/ConnectionFinder'
+import { getInsights, getActors, getActorCollaborators, getActor } from '@/lib/api'
+import type { TrendingChip } from '@/components/HeroSearch'
+import type { NetworkCenter, NetworkNode } from '@/components/GraphPreview'
 
-// Gradient palette — cycle through for variety
-const GRADIENTS: InsightCardData['gradient'][] = [
-  'red',
-  'purple',
-  'orange',
-  'blue',
-]
+// ── Gradient palette ──────────────────────────────────────────────────────────
 
-// Static fallback cards shown even when API is unavailable
-const FALLBACK_CARDS: InsightCardData[] = [
+const GRADIENTS: InsightCardData['gradient'][] = ['red', 'purple', 'orange', 'blue']
+
+const INSIGHT_META: Record<string, { emoji: string; label: string }> = {
+  // Legacy insight types
+  collaboration:    { emoji: '🔥', label: 'Iconic Duo' },
+  director:         { emoji: '🎬', label: 'Director Partnership' },
+  supporting:       { emoji: '⭐', label: 'Character Icon' },
+  // WOW insight types (insight_engine.py)
+  collab_shock:     { emoji: '⚡', label: 'Collaboration Shock' },
+  hidden_dominance: { emoji: '👑', label: 'Hidden Dominance' },
+  cross_industry:   { emoji: '🌏', label: 'Cross-Industry' },
+  career_peak:      { emoji: '📈', label: 'Career Peak' },
+  network_power:    { emoji: '🕸️', label: 'Network Power' },
+  director_loyalty: { emoji: '🤝', label: 'Director Loyalty' },
+}
+
+// ── Static fallbacks ──────────────────────────────────────────────────────────
+
+const FALLBACK_INSIGHT_CARDS: InsightCardData[] = [
   {
     emoji: '🔥',
     label: 'Legendary Duo',
@@ -26,7 +40,7 @@ const FALLBACK_CARDS: InsightCardData[] = [
     subtext: 'The greatest pair in Malayalam cinema',
     actors: [{ name: 'Mohanlal' }, { name: 'Mammootty' }],
     gradient: 'red',
-    href: '/compare/mohanlal-vs-mammootty',
+    href: '/compare',
   },
   {
     emoji: '🎬',
@@ -36,7 +50,7 @@ const FALLBACK_CARDS: InsightCardData[] = [
     subtext: 'Spanning five decades of South Indian cinema',
     actors: [{ name: 'Rajinikanth' }],
     gradient: 'purple',
-    href: '/compare/rajinikanth',
+    href: '/stats',
   },
   {
     emoji: '⭐',
@@ -46,74 +60,44 @@ const FALLBACK_CARDS: InsightCardData[] = [
     subtext: 'Baahubali 2: The Conclusion (2017)',
     actors: [{ name: 'Prabhas' }],
     gradient: 'orange',
-    href: '/compare/prabhas',
-  },
-  {
-    emoji: '🏆',
-    label: 'Director Icon',
-    headline: 'Kamal Haasan has worked with the most directors',
-    stat: '150+',
-    subtext: 'Across Tamil, Telugu, Malayalam, Hindi & more',
-    actors: [{ name: 'Kamal Haasan', avatarSlug: 'kamalhaasan' }],
-    gradient: 'blue',
-    href: '/compare/kamal-haasan',
+    href: '/stats',
   },
 ]
 
-// Fallback trending actors shown when /actors API is unavailable
-const FALLBACK_TRENDING: TrendingActor[] = [
-  { id: 1,  name: 'Rajinikanth',  avatarSlug: 'rajinikanth' },
-  { id: 2,  name: 'Mohanlal',     avatarSlug: 'mohanlal' },
-  { id: 3,  name: 'Kamal Haasan', avatarSlug: 'kamalhaasan' },
-  { id: 4,  name: 'Mammootty',    avatarSlug: 'mammootty' },
-  { id: 5,  name: 'Prabhas',      avatarSlug: 'prabhas' },
-  { id: 6,  name: 'Mahesh Babu',  avatarSlug: 'maheshbabu' },
-  { id: 7,  name: 'Allu Arjun',   avatarSlug: 'alluarjun' },
-  { id: 8,  name: 'Vijay',        avatarSlug: 'vijay' },
-]
+// ── Data helpers ──────────────────────────────────────────────────────────────
 
-const INSIGHT_META: Record<
-  string,
-  { emoji: string; label: string }
-> = {
-  collaboration: { emoji: '🔥', label: 'Iconic Duo' },
-  director:      { emoji: '🎬', label: 'Director Partnership' },
-  supporting:    { emoji: '⭐', label: 'Character Icon' },
-}
-
-async function fetchInsightCards(industry?: string): Promise<InsightCardData[]> {
+async function fetchPageData(industry: string) {
   try {
     const insights = await getInsights(industry)
-    if (!insights.length) return FALLBACK_CARDS
+    if (!insights.length) return { insightCards: FALLBACK_INSIGHT_CARDS }
 
-    return insights.map((insight, i) => {
+    // Build insight cards — take first 3 (any type)
+    const insightCards: InsightCardData[] = insights.slice(0, 3).map((insight, i) => {
       const meta = INSIGHT_META[insight.type] ?? { emoji: '🎭', label: 'Cinema Fact' }
 
-      // Build URL using actor IDs — avoids name→slug roundtrip issues
-      // (e.g. "N. T. Rama Rao Jr." loses dots when slugified → search fails)
-      // collaboration → /compare/id1-vs-id2
-      // director      → /actors/actor_id  (profile shows filmography + directors)
-      // supporting    → /actors/actor_id
       let href = '#'
-      if (insight.type === 'collaboration' && insight.actor_ids.length === 2) {
+      if (
+        (insight.type === 'collaboration' || insight.type === 'collab_shock') &&
+        insight.actor_ids.length === 2
+      ) {
         href = `/compare/${insight.actor_ids[0]}-vs-${insight.actor_ids[1]}`
       } else if (insight.actor_ids.length > 0) {
         href = `/actors/${insight.actor_ids[0]}`
       }
 
-      // For director cards, surface the director's name in the subtext
+      // WOW subtext takes priority; fall back to legacy director label
       const subtext =
-        insight.type === 'director' && insight.actors.length >= 2
+        insight.subtext ??
+        (insight.type === 'director' && insight.actors.length >= 2
           ? `With director ${insight.actors[1]}`
-          : undefined
+          : undefined)
 
       return {
         emoji:    meta.emoji,
         label:    meta.label,
-        headline: insight.headline,
+        headline: insight.title,
         stat:     `${insight.value} ${insight.value === 1 ? 'film' : insight.unit}`,
         subtext,
-        // Show up to 2 actor avatars; for director cards show only the actor (index 0)
         actors:   insight.actors
           .slice(0, insight.type === 'director' ? 1 : 2)
           .map((name) => ({ name })),
@@ -121,156 +105,141 @@ async function fetchInsightCards(industry?: string): Promise<InsightCardData[]> 
         href,
       }
     })
+
+    return { insightCards }
   } catch {
-    return FALLBACK_CARDS
+    return { insightCards: FALLBACK_INSIGHT_CARDS }
   }
 }
 
-// Box office card gradients — cycle through for visual variety
-const BO_GRADIENTS: InsightCardData['gradient'][] = [
-  'green',
-  'orange',
-  'blue',
-  'purple',
-]
+// ── Trending chips — one actor per industry for natural variety ───────────────
 
-/** Format INR crore for display: 2357.9 → "₹2,358 Cr" */
-function formatCrore(crore: number): string {
-  return `₹${Math.round(crore).toLocaleString('en-IN')} Cr`
-}
-
-async function fetchBoxOfficeCards(industry?: string): Promise<InsightCardData[]> {
+async function fetchTrendingChips(): Promise<TrendingChip[]> {
   try {
-    const entries = await getTopBoxOffice(industry, 4)
-    if (!entries.length) return []
-
-    return entries.map((entry: BoxOfficeEntry, i: number) => {
-      const leadName = entry.actor_names[0] ?? null
-      const leadId   = entry.actor_ids[0]  ?? null
-      return {
-        emoji:    '💰',
-        label:    `Box Office #${i + 1}`,
-        headline: `${entry.title} earned worldwide`,
-        stat:     formatCrore(entry.box_office_crore),
-        subtext:  `${entry.industry} · ${entry.release_year}`,
-        actors:   leadName ? [{ name: leadName }] : [],
-        gradient: BO_GRADIENTS[i % BO_GRADIENTS.length],
-        href:     leadId ? `/actors/${leadId}` : '#',
+    const actors = await getActors(true)
+    // Pick first actor per industry so chips span Telugu / Tamil / Malayalam / Kannada
+    const seen = new Set<string>()
+    const chips: TrendingChip[] = []
+    for (const a of actors) {
+      const ind = (a.industry ?? 'other').toLowerCase()
+      if (!seen.has(ind)) {
+        seen.add(ind)
+        chips.push({ id: a.id, name: a.name })
       }
-    })
+      if (chips.length >= 6) break
+    }
+    // If deduplication left fewer than 4, fill straight from the top of the list
+    if (chips.length < 4) {
+      for (const a of actors) {
+        if (!chips.some((c) => c.id === a.id)) chips.push({ id: a.id, name: a.name })
+        if (chips.length >= 6) break
+      }
+    }
+    return chips
   } catch {
     return []
   }
 }
 
-async function fetchTrendingActors(industry?: string): Promise<TrendingActor[]> {
+// ── Network graph data — top collaborators for the graph center actor ─────────
+
+// Fallback if no trending actors are available
+const FALLBACK_CENTER: NetworkCenter = { id: 1, name: 'Rajinikanth', gender: 'M' }
+
+async function fetchNetworkData(
+  first?: { id: number; name: string } | null,
+): Promise<{ center: NetworkCenter; nodes: NetworkNode[] } | null> {
+  // Use first trending actor as center; fall back to Rajinikanth
+  const center: NetworkCenter = first
+    ? { id: first.id, name: first.name }
+    : FALLBACK_CENTER
+
   try {
-    // gender='M' → lead actors only (excludes lead actresses from this row)
-    const actors = await getActors(true, 'M')
-    if (!actors.length) return FALLBACK_TRENDING
+    // Fetch collaborators + actor list in parallel for ID resolution
+    const [collaborators, actors] = await Promise.all([
+      getActorCollaborators(center.id),
+      getActors(true),
+    ])
 
-    // Filter by industry when a tab is selected (case-insensitive match)
-    const filtered =
-      industry && industry !== 'all'
-        ? actors.filter(
-            (a) => a.industry?.toLowerCase() === industry.toLowerCase()
-          )
-        : actors
+    // Build a name → id lookup (case-insensitive) so collaborators get navigable IDs
+    const nameToId = new Map(actors.map(a => [a.name.toLowerCase().trim(), a.id]))
 
-    // Cap at 50 — all primary actors fit comfortably in the scroll row
-    return filtered.slice(0, 50).map((a) => ({
-      id: a.id,
-      name: a.name,
-    }))
+    const nodes: NetworkNode[] = collaborators
+      .slice(0, 8)                          // top 8 by collaboration count (API returns sorted)
+      .map(c => ({
+        id:    nameToId.get(c.actor.toLowerCase().trim()) ?? null,
+        name:  c.actor,
+        films: c.films,
+      }))
+
+    if (nodes.length === 0) return null
+    return { center, nodes }
   } catch {
-    return FALLBACK_TRENDING
+    return null
   }
 }
 
-async function fetchLeadingLadies(industry?: string): Promise<TrendingActor[]> {
-  try {
-    const actresses = await getActors(true, 'F')
-    if (!actresses.length) return []
-
-    const filtered =
-      industry && industry !== 'all'
-        ? actresses.filter(
-            (a) => a.industry?.toLowerCase() === industry.toLowerCase()
-          )
-        : actresses
-
-    return filtered.slice(0, 50).map((a) => ({
-      id: a.id,
-      name: a.name,
-    }))
-  } catch {
-    return []
-  }
-}
+// ── Page ──────────────────────────────────────────────────────────────────────
 
 export default async function HomePage({
   searchParams,
 }: {
-  searchParams?: { industry?: string }
+  searchParams?: { actor?: string }
 }) {
-  // Read the active industry from the URL (?industry=telugu) or default to 'all'
-  const industry = searchParams?.industry ?? 'all'
-
-  const [insightCards, boxOfficeCards, trendingActors, leadingLadies] = await Promise.all([
-    fetchInsightCards(industry),
-    fetchBoxOfficeCards(industry),
-    fetchTrendingActors(industry),
-    fetchLeadingLadies(industry),
+  // Fetch page data + trending chips in parallel; chips[0] drives the graph center
+  const [{ insightCards }, trendingChips] = await Promise.all([
+    fetchPageData('all'),
+    fetchTrendingChips(),
   ])
+
+  // ?actor= URL param overrides the network center (used by Share button on GraphPreview)
+  let networkCenter: { id: number; name: string } | null = trendingChips[0] ?? null
+  if (searchParams?.actor) {
+    const actorId = Number(searchParams.actor)
+    if (!Number.isNaN(actorId)) {
+      try {
+        const profile = await getActor(actorId)
+        networkCenter = { id: profile.id, name: profile.name }
+      } catch {
+        // Fall back to trending actor if ID is invalid / actor not found
+      }
+    }
+  }
+
+  // Network data runs after chips resolve so we can pass the center actor
+  const networkData = await fetchNetworkData(networkCenter)
 
   return (
     <div className="min-h-screen bg-[#0a0a0f]">
-      {/* Header */}
       <Header />
 
-      {/* Glass Nav — aligned to same container */}
-      <div className="max-w-[1200px] mx-auto px-6">
-        <NavTabs activeTab={industry} />
-      </div>
+      <main className="max-w-[1200px] mx-auto px-6 pb-24">
 
-      {/* Page content */}
-      <main className="max-w-[1200px] mx-auto px-6 mt-10 pb-20">
-        {/* Section title */}
-        <h1 className="text-xl font-bold text-white/80 mt-10 mb-6">
-          🔥 Cinema Insights
-        </h1>
+        {/* ── 1. Hero ───────────────────────────────────────────────────────── */}
+        <HeroSearch trendingActors={trendingChips} />
 
-        {/* 2×N Insight Cards Grid */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          {insightCards.map((card, i) => (
-            <InsightCard key={i} {...card} />
-          ))}
-        </div>
+        {/* ── 2. Connection Finder ─────────────────────────────────────────── */}
+        <section className="mt-16">
+          <h2 className="text-xs font-semibold uppercase tracking-widest text-white/40 mb-5">
+            🔗 Connection Finder
+          </h2>
+          <ConnectionFinder />
+        </section>
 
-        {/* Box Office Leaderboard */}
-        {boxOfficeCards.length > 0 && (
-          <>
-            <h2 className="text-xl font-bold text-white/80 mt-12 mb-6">
-              💰 Box Office Leaderboard
-            </h2>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              {boxOfficeCards.map((card, i) => (
-                <InsightCard key={i} {...card} />
-              ))}
-            </div>
-          </>
-        )}
+        {/* ── 3. Graph Preview ─────────────────────────────────────────────── */}
+        <section className="mt-16">
+          <GraphPreview networkData={networkData} />
+        </section>
+
+        {/* ── 4. Insights (auto-scroll carousel) ───────────────────────────── */}
+        <section className="mt-16">
+          <h2 className="text-xs font-semibold uppercase tracking-widest text-white/40 mb-5">
+            🔥 Cinema Insights
+          </h2>
+          <InsightsCarousel cards={insightCards} />
+        </section>
+
       </main>
-
-      {/* Lead Actors Row */}
-      <TrendingActors actors={trendingActors} title="🎬 Lead Actors" />
-
-      {/* Leading Ladies Row — only shown when there are results */}
-      {leadingLadies.length > 0 && (
-        <TrendingActors actors={leadingLadies} title="🌟 Leading Ladies" />
-      )}
-
-      <div className="h-16" />
     </div>
   )
 }

--- a/frontend/components/ConnectionResult.tsx
+++ b/frontend/components/ConnectionResult.tsx
@@ -1,0 +1,385 @@
+'use client'
+
+/**
+ * ConnectionResult — Progressive center-focused path animation.
+ *
+ * Reveals Actor → Movie → Actor → … one node at a time.
+ * The current node is always centered in the viewport; previous nodes
+ * shift left. Uses only CSS transitions + a setTimeout chain — no libs.
+ *
+ * Layout (px, fixed widths make translateX maths exact):
+ *   Actor node  : ACTOR_W  = 80 px
+ *   Movie node  : MOVIE_W  = 120 px
+ *   Connector   : CONN_W   = 44 px (between every pair of nodes)
+ *   Track height: 116 px   (fits 52px avatar + 8px gap + 14px name, scaled)
+ *
+ * Sequence timing:
+ *   STEP_MS = 520 ms between advances; total ≤ 4 s for a 6-degree path.
+ *
+ * Controls (shown after animation completes):
+ *   ↩ Replay  — resets step to 0, re-runs the reveal animation
+ *   🔗 Share  — Web Share API with clipboard fallback + "Link copied!" toast
+ *               URL: /connect?from={actor1_id}&to={actor2_id}
+ */
+
+import { useState, useEffect, useRef } from 'react'
+import { useRouter } from 'next/navigation'
+import ActorAvatar from '@/components/ActorAvatar'
+import type { ConnectionPath } from '@/lib/api'
+
+// ── Sizing ─────────────────────────────────────────────────────────────────────
+
+const ACTOR_W = 80
+const MOVIE_W = 120
+const CONN_W  = 44
+const STEP_MS = 520
+
+// ── Item model ─────────────────────────────────────────────────────────────────
+
+type Item =
+  | { kind: 'actor'; id: number; name: string }
+  | { kind: 'movie'; id: number; title: string }
+
+function buildItems(result: ConnectionPath): Item[] {
+  const out: Item[] = []
+  result.path.forEach((actor, i) => {
+    out.push({ kind: 'actor', id: actor.id, name: actor.name })
+    if (i < result.connections.length) {
+      out.push({
+        kind:  'movie',
+        id:    result.connections[i].movie_id,
+        title: result.connections[i].movie_title,
+      })
+    }
+  })
+  return out
+}
+
+function itemWidth(item: Item) {
+  return item.kind === 'actor' ? ACTOR_W : MOVIE_W
+}
+
+// ── Actor node ─────────────────────────────────────────────────────────────────
+
+function ActorNode({
+  item, active, past, onClick,
+}: {
+  item:    Extract<Item, { kind: 'actor' }>
+  active:  boolean
+  past:    boolean
+  onClick: () => void
+}) {
+  return (
+    <div
+      onClick={active || past ? onClick : undefined}
+      style={{
+        width:         ACTOR_W,
+        flexShrink:    0,
+        display:       'flex',
+        flexDirection: 'column',
+        alignItems:    'center',
+        gap:           8,
+        opacity:       active ? 1 : past ? 0.38 : 0,
+        transform:     active ? 'scale(1.08)' : 'scale(1)',
+        transition:    'opacity 0.38s ease, transform 0.38s cubic-bezier(0.34,1.3,0.64,1)',
+        cursor:        active || past ? 'pointer' : 'default',
+        pointerEvents: active || past ? 'auto' : 'none',
+      }}
+    >
+      <ActorAvatar name={item.name} size={52} />
+      <p style={{
+        color:      active ? 'rgba(255,255,255,0.90)' : 'rgba(255,255,255,0.55)',
+        fontSize:   11,
+        fontWeight: 600,
+        textAlign:  'center',
+        lineHeight: 1.3,
+        maxWidth:   ACTOR_W,
+        margin:     0,
+        transition: 'color 0.38s ease',
+      }}>
+        {/* First name only keeps labels compact */}
+        {item.name.split(' ')[0]}
+      </p>
+    </div>
+  )
+}
+
+// ── Movie node ─────────────────────────────────────────────────────────────────
+
+function MovieNode({
+  item, active, past,
+}: {
+  item:   Extract<Item, { kind: 'movie' }>
+  active: boolean
+  past:   boolean
+}) {
+  return (
+    <div style={{
+      width:         MOVIE_W,
+      flexShrink:    0,
+      display:       'flex',
+      alignItems:    'center',
+      justifyContent: 'center',
+      opacity:       active ? 1 : past ? 0.38 : 0,
+      transform:     active ? 'scale(1.05)' : 'scale(1)',
+      transition:    'opacity 0.38s ease, transform 0.38s ease',
+      pointerEvents: 'none',
+    }}>
+      <div style={{
+        borderRadius: 12,
+        padding:      '8px 12px',
+        background:   active ? 'rgba(255,255,255,0.09)' : 'rgba(255,255,255,0.04)',
+        border:       `1px solid ${active ? 'rgba(255,255,255,0.22)' : 'rgba(255,255,255,0.07)'}`,
+        transition:   'background 0.38s ease, border-color 0.38s ease',
+        maxWidth:     MOVIE_W - 8,
+        textAlign:    'center',
+      }}>
+        <p style={{
+          color:      'rgba(255,255,255,0.75)',
+          fontSize:   10,
+          fontWeight: 500,
+          lineHeight: 1.45,
+          margin:     0,
+        }}>
+          {item.title}
+        </p>
+      </div>
+    </div>
+  )
+}
+
+// ── Connector line ─────────────────────────────────────────────────────────────
+
+function Connector({ shown }: { shown: boolean }) {
+  return (
+    <div style={{ width: CONN_W, flexShrink: 0, display: 'flex', alignItems: 'center' }}>
+      <div style={{
+        height:     1,
+        background: 'rgba(255,255,255,0.18)',
+        width:      shown ? '100%' : '0%',
+        // Slight delay: line draws after the incoming node starts appearing
+        transition: shown ? 'width 0.28s ease 0.12s' : 'none',
+      }} />
+    </div>
+  )
+}
+
+// ── Main ───────────────────────────────────────────────────────────────────────
+
+export default function ConnectionResult({ result }: { result: ConnectionPath }) {
+  const router       = useRouter()
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [step,       setStep]       = useState(0)
+  const [containerW, setContainerW] = useState(600) // sensible default; corrected after mount
+  const [toast,      setToast]      = useState<string | null>(null)
+
+  const items   = buildItems(result)
+  const maxStep = items.length - 1
+  const done    = step >= maxStep
+
+  // ── Measure real container width once after mount ──
+  useEffect(() => {
+    if (containerRef.current) setContainerW(containerRef.current.clientWidth)
+  }, [])
+
+  // ── Auto-advance: one step every STEP_MS ms ──
+  useEffect(() => {
+    if (step >= maxStep) return
+    const tid = setTimeout(() => setStep(s => s + 1), STEP_MS)
+    return () => clearTimeout(tid)
+  }, [step, maxStep])
+
+  // ── translateX so the active item is horizontally centred ──
+  // leftEdge = sum of (itemWidth + CONN_W) for items 0 … step-1
+  function calcTranslate(atStep: number): number {
+    let leftEdge = 0
+    for (let i = 0; i < atStep; i++) {
+      leftEdge += itemWidth(items[i]) + CONN_W
+    }
+    const curW = atStep < items.length ? itemWidth(items[atStep]) : ACTOR_W
+    return containerW / 2 - leftEdge - curW / 2
+  }
+
+  // ── Replay: reset to beginning ──
+  function handleReplay() {
+    setStep(0)
+  }
+
+  // ── Share: Web Share API with clipboard fallback ──
+  async function handleShare() {
+    const actor1Id = result.path[0]?.id
+    const actor2Id = result.path.at(-1)?.id
+    const url = typeof window !== 'undefined'
+      ? `${window.location.origin}/connect?from=${actor1Id}&to=${actor2Id}`
+      : `/connect?from=${actor1Id}&to=${actor2Id}`
+
+    const shareData = {
+      title: `${result.path[0]?.name} → ${result.path.at(-1)?.name}`,
+      text:  `Connected in ${result.depth} step${result.depth !== 1 ? 's' : ''} on South Cinema Analytics`,
+      url,
+    }
+
+    try {
+      if (navigator.share && navigator.canShare?.(shareData)) {
+        await navigator.share(shareData)
+      } else {
+        await navigator.clipboard.writeText(url)
+        showToast('Link copied!')
+      }
+    } catch {
+      // User cancelled share or clipboard failed gracefully
+      try {
+        await navigator.clipboard.writeText(url)
+        showToast('Link copied!')
+      } catch {
+        // Nothing we can do
+      }
+    }
+  }
+
+  function showToast(msg: string) {
+    setToast(msg)
+    setTimeout(() => setToast(null), 2200)
+  }
+
+  // ── No-path fallback ──
+  if (!result.found) {
+    return (
+      <div className="text-center py-8">
+        <p className="text-3xl mb-3">🔍</p>
+        <p className="text-white/60 text-sm">No connection found within 6 degrees.</p>
+      </div>
+    )
+  }
+
+  const translateX = calcTranslate(step)
+
+  return (
+    <div className="mt-6">
+
+      {/* ── Depth label ── */}
+      <p className="text-center text-white/40 text-xs uppercase tracking-widest mb-6">
+        Connected in{' '}
+        <span className="text-white font-bold">{result.depth}</span>{' '}
+        step{result.depth !== 1 ? 's' : ''}
+      </p>
+
+      {/* ── Track ── */}
+      {/* overflow: hidden masks nodes outside the viewport; height is fixed so
+          the scaled active node doesn't cause layout reflow */}
+      <div
+        ref={containerRef}
+        className="relative overflow-hidden"
+        style={{ height: 116 }}
+      >
+        <div
+          className="absolute inset-y-0 flex items-center"
+          style={{
+            transform:  `translateX(${translateX}px)`,
+            transition: 'transform 0.50s cubic-bezier(0.4, 0, 0.2, 1)',
+            willChange: 'transform',
+          }}
+        >
+          {items.map((item, i) => (
+            <div key={i} style={{ display: 'flex', alignItems: 'center' }}>
+              {/* Connector appears before every node except the first */}
+              {i > 0 && <Connector shown={i <= step} />}
+
+              {item.kind === 'actor' ? (
+                <ActorNode
+                  item={item}
+                  active={i === step}
+                  past={i < step}
+                  onClick={() => router.push(`/actors/${item.id}`)}
+                />
+              ) : (
+                <MovieNode
+                  item={item}
+                  active={i === step}
+                  past={i < step}
+                />
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* ── Progress dots ── */}
+      {/* Actors get larger dots; movies get smaller. Click a past dot to replay from there. */}
+      <div className="flex justify-center items-center gap-2 mt-5">
+        {items.map((item, i) => (
+          <button
+            key={i}
+            aria-label={item.kind === 'actor' ? item.name : item.title}
+            onClick={() => i < step ? setStep(i) : undefined}
+            style={{
+              width:        item.kind === 'actor' ? 7 : 5,
+              height:       item.kind === 'actor' ? 7 : 5,
+              borderRadius: '50%',
+              border:       'none',
+              padding:      0,
+              flexShrink:   0,
+              background:
+                i === step ? 'rgba(255,255,255,0.90)' :
+                i <  step  ? 'rgba(255,255,255,0.40)' :
+                              'rgba(255,255,255,0.12)',
+              transition: 'background 0.3s ease',
+              cursor:     i < step ? 'pointer' : 'default',
+            }}
+          />
+        ))}
+      </div>
+
+      {/* ── Replay + Share buttons — appear after animation completes ── */}
+      <div
+        className="flex justify-center gap-3 mt-6"
+        style={{
+          opacity:    done ? 1 : 0,
+          transform:  done ? 'translateY(0)' : 'translateY(6px)',
+          transition: 'opacity 0.4s ease 0.1s, transform 0.4s ease 0.1s',
+          pointerEvents: done ? 'auto' : 'none',
+        }}
+      >
+        <button
+          onClick={handleReplay}
+          className="flex items-center gap-1.5 px-4 py-2 rounded-full text-xs font-semibold transition-all
+                     bg-white/[0.07] border border-white/[0.12] text-white/55
+                     hover:bg-white/[0.12] hover:text-white/80 hover:border-white/25"
+        >
+          ↩ Replay
+        </button>
+
+        <button
+          onClick={handleShare}
+          className="flex items-center gap-1.5 px-4 py-2 rounded-full text-xs font-semibold transition-all
+                     bg-white/[0.07] border border-white/[0.12] text-white/55
+                     hover:bg-white/[0.12] hover:text-white/80 hover:border-white/25"
+        >
+          🔗 Share
+        </button>
+      </div>
+
+      {/* ── Toast notification ── */}
+      {toast && (
+        <div
+          className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50
+                     px-4 py-2 rounded-full text-xs font-semibold
+                     bg-white text-[#0a0a0f] shadow-lg shadow-black/40"
+          style={{
+            animation: 'fadeInUp 0.2s ease',
+          }}
+        >
+          {toast}
+        </div>
+      )}
+
+      <style>{`
+        @keyframes fadeInUp {
+          from { opacity: 0; transform: translate(-50%, 8px); }
+          to   { opacity: 1; transform: translate(-50%, 0); }
+        }
+      `}</style>
+
+    </div>
+  )
+}

--- a/frontend/components/GraphPreview.tsx
+++ b/frontend/components/GraphPreview.tsx
@@ -1,0 +1,352 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+// ── Toast helper (inline; no extra dep) ──────────────────────────────────────
+
+function useToast() {
+  const [toast, setToast] = useState<string | null>(null)
+  function showToast(msg: string) {
+    setToast(msg)
+    setTimeout(() => setToast(null), 2200)
+  }
+  return { toast, showToast }
+}
+
+// ── Exported types (consumed by page.tsx) ────────────────────────────────────
+
+export interface NetworkNode {
+  id: number | null  // null → no click navigation
+  name: string
+  films: number      // shared films with center actor
+}
+
+export interface NetworkCenter {
+  id: number
+  name: string
+  gender?: 'M' | 'F' | null
+}
+
+// ── Layout constants ──────────────────────────────────────────────────────────
+
+const SVG_W = 480
+const SVG_H = 340
+const CX = SVG_W / 2        // 240 — horizontal center
+const CY = SVG_H / 2 - 10  // 160 — vertical center (slightly above mid)
+const RING_R = 128           // radius of surrounding node ring
+const CENTER_R = 34          // center node circle radius (~13% larger for prominence)
+const NODE_R = 19            // surrounding node circle radius
+
+// Colour palette — matches existing graph visual style
+const COLORS = [
+  '#8b5cf6', '#3b82f6', '#10b981', '#f59e0b',
+  '#ec4899', '#06b6d4', '#ef4444', '#a3e635',
+]
+const CENTER_COLOR = '#ef4444'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Position of surrounding node i out of total on a circle */
+function polarPos(i: number, total: number) {
+  const angle = (2 * Math.PI * i / total) - Math.PI / 2  // start from top
+  return {
+    x: CX + RING_R * Math.cos(angle),
+    y: CY + RING_R * Math.sin(angle),
+  }
+}
+
+/** Up to 2 capital initials from a name */
+function initials(name: string) {
+  return name.split(' ').map(w => w[0] ?? '').join('').slice(0, 2).toUpperCase()
+}
+
+/** Gender-aware pronoun for subtitle */
+function pronoun(gender?: 'M' | 'F' | null) {
+  return gender === 'F' ? 'she' : 'he'
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export default function GraphPreview({
+  networkData,
+}: {
+  networkData: { center: NetworkCenter; nodes: NetworkNode[] } | null
+}) {
+  const router = useRouter()
+  const [hovered, setHovered] = useState<'center' | number | null>(null)
+  const { toast, showToast } = useToast()
+
+  /** Scroll to and focus the hero search input */
+  function scrollToHeroSearch() {
+    const input = document.getElementById('hero-search-input') as HTMLInputElement | null
+    if (input) {
+      input.scrollIntoView({ behavior: 'smooth', block: 'center' })
+      setTimeout(() => input.focus(), 500)
+    }
+  }
+
+  /** Share this network by URL: /?actor={center.id} */
+  async function handleShare() {
+    if (!center) return
+    const url = typeof window !== 'undefined'
+      ? `${window.location.origin}/?actor=${center.id}`
+      : `/?actor=${center.id}`
+    const shareData = {
+      title: `${center.name}'s Cinema Network`,
+      text:  `Explore ${center.name}'s collaboration network on South Cinema Analytics`,
+      url,
+    }
+    try {
+      if (navigator.share && navigator.canShare?.(shareData)) {
+        await navigator.share(shareData)
+      } else {
+        await navigator.clipboard.writeText(url)
+        showToast('Link copied!')
+      }
+    } catch {
+      try {
+        await navigator.clipboard.writeText(url)
+        showToast('Link copied!')
+      } catch { /* nothing we can do */ }
+    }
+  }
+
+  const center   = networkData?.center
+  const nodes    = (networkData?.nodes ?? []).slice(0, 8)
+  const title    = center ? `${center.name}'s Network` : 'Cinema Network'
+  const subtitle = center
+    ? `Actors ${pronoun(center.gender)} has collaborated with across industries`
+    : 'Explore collaboration networks'
+
+  return (
+    <div
+      className="rounded-3xl border border-white/[0.08] overflow-hidden"
+      style={{ background: '#0d0d15' }}
+    >
+      {/* ── Header ── */}
+      <div className="px-6 pt-6 pb-3 flex items-center justify-between">
+        <div>
+          <p className="text-[10px] font-semibold uppercase tracking-[0.15em] text-white/25 mb-1">
+            Showing network for
+          </p>
+          <h2 className="text-base font-bold text-white flex items-center gap-2">
+            🌐 {title}
+          </h2>
+          <p className="text-white/30 text-xs mt-0.5">{subtitle}</p>
+        </div>
+        <div className="flex items-center gap-2 flex-shrink-0">
+          {/* Share this network */}
+          {center && (
+            <button
+              onClick={handleShare}
+              className="text-xs font-semibold px-3 py-1.5 rounded-full bg-white/[0.07] border border-white/[0.12] text-white/50 hover:text-white/80 hover:border-white/25 transition-all"
+              aria-label="Share network"
+            >
+              🔗
+            </button>
+          )}
+          <button
+            onClick={scrollToHeroSearch}
+            className="text-xs font-semibold px-4 py-1.5 rounded-full bg-white/[0.07] border border-white/[0.12] text-white/60 hover:text-white hover:border-white/25 transition-all"
+          >
+            Explore your favourite actor →
+          </button>
+        </div>
+      </div>
+
+      {/* ── Graph or fallback ── */}
+      <div className="px-4 pb-5">
+        {!center || nodes.length === 0 ? (
+
+          // No data — clean fallback message
+          <div
+            className="w-full rounded-2xl flex items-center justify-center"
+            style={{ background: '#08080f', minHeight: 200 }}
+          >
+            <p className="text-white/20 text-sm">No collaboration data available yet</p>
+          </div>
+
+        ) : (
+
+          // Star graph — center + surrounding collaborators
+          // Only center → collaborator edges; NO cross-edges between collaborators
+          <svg
+            viewBox={`0 0 ${SVG_W} ${SVG_H}`}
+            className="w-full rounded-2xl"
+            style={{ background: '#08080f', display: 'block', maxHeight: 320 }}
+          >
+            {/* ── Edges: center → each collaborator only ── */}
+            {nodes.map((node, i) => {
+              const { x, y } = polarPos(i, nodes.length)
+              const lit   = hovered === i || hovered === 'center'
+              const faded = hovered !== null && !lit
+              return (
+                <line
+                  key={i}
+                  x1={CX} y1={CY}
+                  x2={x}  y2={y}
+                  stroke={
+                    lit   ? 'rgba(255,255,255,0.38)' :
+                    faded ? 'rgba(255,255,255,0.03)' :
+                            'rgba(255,255,255,0.10)'
+                  }
+                  strokeWidth={lit ? 2 : 1}
+                  style={{ transition: 'stroke 0.15s ease, stroke-width 0.15s ease' }}
+                />
+              )
+            })}
+
+            {/* ── Surrounding nodes (collaborators) ── */}
+            {nodes.map((node, i) => {
+              const { x, y } = polarPos(i, nodes.length)
+              const color = COLORS[i % COLORS.length]
+              const isHov = hovered === i
+              const faded = hovered !== null && hovered !== i && hovered !== 'center'
+
+              return (
+                <g
+                  key={i}
+                  style={{
+                    cursor: node.id ? 'pointer' : 'default',
+                    opacity: faded ? 0.22 : 1,
+                    transition: 'opacity 0.15s ease',
+                  }}
+                  onMouseEnter={() => setHovered(i)}
+                  onMouseLeave={() => setHovered(null)}
+                  onClick={() => node.id && router.push(`/actors/${node.id}`)}
+                >
+                  {/* Glow ring on hover */}
+                  {isHov && (
+                    <circle cx={x} cy={y} r={NODE_R + 11} fill={color} opacity={0.14} />
+                  )}
+
+                  {/* Node circle */}
+                  <circle
+                    cx={x} cy={y} r={NODE_R}
+                    fill={isHov ? color : color + '2e'}
+                    stroke={color}
+                    strokeWidth={isHov ? 2 : 1.5}
+                    strokeOpacity={isHov ? 1 : 0.55}
+                    style={{ transition: 'fill 0.15s ease, stroke-opacity 0.15s ease' }}
+                  />
+
+                  {/* Initials */}
+                  <text
+                    x={x} y={y}
+                    textAnchor="middle" dominantBaseline="central"
+                    fontSize={9} fontWeight="700"
+                    fill={isHov ? '#fff' : color}
+                    style={{ userSelect: 'none', transition: 'fill 0.15s ease' }}
+                  >
+                    {initials(node.name)}
+                  </text>
+
+                  {/* Name label — always below node */}
+                  <text
+                    x={x} y={y + NODE_R + 13}
+                    textAnchor="middle" fontSize="9"
+                    fill={isHov ? 'rgba(255,255,255,0.80)' : 'rgba(255,255,255,0.30)'}
+                    style={{ userSelect: 'none', transition: 'fill 0.15s ease' }}
+                  >
+                    {node.name.split(' ')[0]}
+                  </text>
+
+                  {/* Film count — two overlapping layers cross-fade; no layout shift */}
+                  {/* Layer 1: bare number, visible at rest, fades out on hover */}
+                  <text
+                    x={x} y={y + NODE_R + 24}
+                    textAnchor="middle" fontSize="7.5"
+                    fill="rgba(255,255,255,0.18)"
+                    style={{ userSelect: 'none', transition: 'opacity 0.18s ease', opacity: isHov ? 0 : 1 }}
+                  >
+                    {node.films}
+                  </text>
+                  {/* Layer 2: "N films", invisible at rest, fades in on hover */}
+                  <text
+                    x={x} y={y + NODE_R + 24}
+                    textAnchor="middle" fontSize="7.5"
+                    fill="rgba(255,255,255,0.50)"
+                    style={{ userSelect: 'none', transition: 'opacity 0.18s ease', opacity: isHov ? 1 : 0 }}
+                  >
+                    {node.films} films
+                  </text>
+                </g>
+              )
+            })}
+
+            {/* ── Center node (the selected actor) ── */}
+            <g
+              style={{ cursor: 'pointer' }}
+              onMouseEnter={() => setHovered('center')}
+              onMouseLeave={() => setHovered(null)}
+              onClick={() => router.push(`/actors/${center.id}`)}
+            >
+              {/* Glow ring */}
+              {hovered === 'center' && (
+                <circle cx={CX} cy={CY} r={CENTER_R + 12} fill={CENTER_COLOR} opacity={0.15} />
+              )}
+
+              {/* Node circle */}
+              <circle
+                cx={CX} cy={CY} r={CENTER_R}
+                fill={hovered === 'center' ? CENTER_COLOR : CENTER_COLOR + '33'}
+                stroke={CENTER_COLOR}
+                strokeWidth={hovered === 'center' ? 2 : 1.5}
+                strokeOpacity={hovered === 'center' ? 1 : 0.70}
+                style={{ transition: 'fill 0.15s ease' }}
+              />
+
+              {/* Initials */}
+              <text
+                x={CX} y={CY}
+                textAnchor="middle" dominantBaseline="central"
+                fontSize={Math.round(CENTER_R * 0.52)} fontWeight="700"
+                fill={hovered === 'center' ? '#fff' : CENTER_COLOR}
+                style={{ userSelect: 'none', transition: 'fill 0.15s ease' }}
+              >
+                {initials(center.name)}
+              </text>
+
+              {/* Name label */}
+              <text
+                x={CX} y={CY + CENTER_R + 13}
+                textAnchor="middle" fontSize="9.5"
+                fill={hovered === 'center' ? 'rgba(255,255,255,0.80)' : 'rgba(255,255,255,0.50)'}
+                style={{ userSelect: 'none', transition: 'fill 0.15s ease' }}
+              >
+                {center.name.split(' ')[0]}
+              </text>
+            </g>
+          </svg>
+
+        )}
+
+        {/* Legend — only shown when graph is visible */}
+        {center && nodes.length > 0 && (
+          <p className="text-center text-[10px] text-white/15 mt-3 tracking-wide">
+            Lines represent shared films
+          </p>
+        )}
+      </div>
+
+      {/* Toast notification */}
+      {toast && (
+        <div
+          className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50
+                     px-4 py-2 rounded-full text-xs font-semibold
+                     bg-white text-[#0a0a0f] shadow-lg shadow-black/40"
+          style={{ animation: 'fadeInUpGraph 0.2s ease' }}
+        >
+          {toast}
+        </div>
+      )}
+      <style>{`
+        @keyframes fadeInUpGraph {
+          from { opacity: 0; transform: translate(-50%, 8px); }
+          to   { opacity: 1; transform: translate(-50%, 0); }
+        }
+      `}</style>
+    </div>
+  )
+}

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -1,14 +1,11 @@
-'use client'
-
 import Image from 'next/image'
 import Link from 'next/link'
-import SearchBar from './SearchBar'
 
 export default function Header() {
   return (
-    <header className="w-full px-6 py-4 flex items-center gap-4 max-w-[1200px] mx-auto">
+    <header className="w-full px-6 py-4 max-w-[1200px] mx-auto">
       {/* Narada avatar — links to homepage */}
-      <Link href="/" className="flex-shrink-0">
+      <Link href="/" className="inline-flex flex-shrink-0">
         <div className="w-11 h-11 rounded-full overflow-hidden border border-white/10 hover:scale-105 transition-transform duration-200">
           <Image
             src="/narada.jpeg"
@@ -21,11 +18,6 @@ export default function Header() {
           />
         </div>
       </Link>
-
-      {/* Search bar — fills remaining space */}
-      <div className="flex-1">
-        <SearchBar />
-      </div>
     </header>
   )
 }

--- a/frontend/components/HeroSearch.tsx
+++ b/frontend/components/HeroSearch.tsx
@@ -1,0 +1,113 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import ActorAvatar from '@/components/ActorAvatar'
+
+export interface TrendingChip {
+  id: number
+  name: string
+}
+
+export default function HeroSearch({ trendingActors = [] }: { trendingActors?: TrendingChip[] }) {
+  const [query, setQuery] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [notFound, setNotFound] = useState(false)
+  const router = useRouter()
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const q = query.trim()
+    if (!q) return
+
+    setLoading(true)
+    setNotFound(false)
+
+    try {
+      const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8000'
+      const res = await fetch(`${apiUrl}/actors/search?q=${encodeURIComponent(q)}`)
+      const results = await res.json()
+
+      if (results.length > 0) {
+        router.push(`/actors/${results[0].id}`)
+      } else {
+        setNotFound(true)
+        setLoading(false)
+      }
+    } catch {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <section className="flex flex-col items-center text-center pt-10 pb-4">
+      <h1 className="text-[2rem] sm:text-[2.75rem] font-black text-white leading-[1.15] tracking-[-0.02em] max-w-xl">
+        Explore South Indian<br />Cinema Connections
+      </h1>
+      <p className="mt-4 text-sm text-white/40 max-w-sm leading-relaxed">
+        Discover how actors are connected across Telugu, Tamil, Malayalam &amp; Kannada cinema.
+      </p>
+
+      {/* Big search bar */}
+      <form onSubmit={handleSubmit} className="relative w-full max-w-lg mt-8">
+        <span className="absolute left-5 top-1/2 -translate-y-1/2 text-white/30 pointer-events-none">
+          {loading ? (
+            <svg className="animate-spin" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+            </svg>
+          ) : (
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="11" cy="11" r="8" />
+              <line x1="21" y1="21" x2="16.65" y2="16.65" />
+            </svg>
+          )}
+        </span>
+        <input
+          id="hero-search-input"
+          type="text"
+          value={query}
+          onChange={(e) => { setQuery(e.target.value); setNotFound(false) }}
+          placeholder="Search an actor to explore their network (Try: Rajinikanth, Prabhas)"
+          disabled={loading}
+          autoComplete="off"
+          className="
+            w-full pl-12 pr-5 py-4 rounded-full text-sm
+            bg-white/[0.07] border border-white/[0.12]
+            text-white placeholder-white/25
+            focus:outline-none focus:border-white/25 focus:bg-white/[0.10]
+            transition-all duration-200 disabled:opacity-60
+          "
+        />
+        {notFound && (
+          <span className="absolute right-5 top-1/2 -translate-y-1/2 text-xs text-white/35">
+            No results
+          </span>
+        )}
+      </form>
+
+      {/* Actor chips — navigate to actor profile on click */}
+      {trendingActors.length > 0 && (
+        <div className="flex flex-wrap gap-2 justify-center mt-5">
+          {trendingActors.map((actor) => (
+            <Link
+              key={actor.id}
+              href={`/actors/${actor.id}`}
+              className="
+                inline-flex items-center gap-2
+                pl-1.5 pr-4 py-1.5 rounded-full
+                bg-white/[0.05] border border-white/[0.09]
+                text-white/50 hover:text-white/80 hover:bg-white/[0.09] hover:border-white/[0.18]
+                hover:scale-[1.03]
+                transition-all duration-200
+              "
+            >
+              <ActorAvatar name={actor.name} size={22} />
+              <span className="text-xs">{actor.name}</span>
+            </Link>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/frontend/components/InsightsCarousel.tsx
+++ b/frontend/components/InsightsCarousel.tsx
@@ -1,0 +1,137 @@
+'use client'
+
+/**
+ * InsightsCarousel — auto-scrolling carousel for Cinema Insight cards.
+ *
+ * Behaviour
+ * - Slow, continuous left→right scroll using requestAnimationFrame
+ * - Pauses on hover or focus (user interaction)
+ * - Pauses when tab is hidden (visibilitychange)
+ * - Pauses when scrolled off-screen (IntersectionObserver)
+ * - Resumes automatically when all pause conditions clear
+ * - Manual scroll (trackpad / touch) works at any time — RAF picks up from
+ *   wherever the user scrolled to
+ * - Infinite loop: cards are tripled so the seam is never visible; scrollLeft
+ *   resets silently when it reaches 1/3 of the total track width
+ * - Edge fade: CSS mask gradient on left + right for a Netflix-style look
+ *
+ * Implementation notes
+ * - No animation library — pure RAF + scrollLeft manipulation
+ * - Two refs (hoverPausedRef, viewPausedRef) avoid re-renders on pause toggles
+ * - scrollbarWidth: none hides the scrollbar cross-browser
+ */
+
+import { useEffect, useRef } from 'react'
+import InsightCard, { type InsightCardData } from '@/components/InsightCard'
+
+// Width of each card in px — ~10 % wider than a 3-col grid cell at 1 200 px
+const CARD_W = 360
+
+// Scroll speed in px / ms  →  ~50 px/s  →  slow, comfortable for reading
+const SPEED = 0.05
+
+export default function InsightsCarousel({
+  cards,
+}: {
+  cards: InsightCardData[]
+}) {
+  const scrollRef     = useRef<HTMLDivElement>(null)
+  // Paused by hover or keyboard focus
+  const hoverPausedRef = useRef(false)
+  // Paused because tab is hidden or element is off-screen
+  const viewPausedRef  = useRef(false)
+  // Track latest intersection state for use inside the visibilitychange handler
+  const isIntersectingRef = useRef(true)
+
+  // Triple the set — the loop resets after 1/3 of total scroll width
+  const items = cards.length > 0 ? [...cards, ...cards, ...cards] : cards
+
+  useEffect(() => {
+    const el = scrollRef.current
+    if (!el || items.length === 0) return
+
+    // ── RAF loop ──────────────────────────────────────────────────────────────
+    let rafId: number
+    let prev: DOMHighResTimeStamp | null = null
+
+    function tick(now: DOMHighResTimeStamp) {
+      const dt = prev != null ? now - prev : 0
+      prev = now
+
+      if (!hoverPausedRef.current && !viewPausedRef.current && el) {
+        el.scrollLeft += SPEED * dt
+
+        // Seamless reset: jump back one "set" when we cross the 1/3 boundary
+        const setWidth = el.scrollWidth / 3
+        if (el.scrollLeft >= setWidth) {
+          el.scrollLeft -= setWidth
+        }
+      }
+
+      rafId = requestAnimationFrame(tick)
+    }
+
+    rafId = requestAnimationFrame(tick)
+
+    // ── IntersectionObserver — pause when not in viewport ──────────────────
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        isIntersectingRef.current = entry.isIntersecting
+        viewPausedRef.current = document.hidden || !entry.isIntersecting
+      },
+      { threshold: 0.1 },
+    )
+    observer.observe(el)
+
+    // ── visibilitychange — pause when tab is hidden ────────────────────────
+    function onVisibility() {
+      viewPausedRef.current = document.hidden || !isIntersectingRef.current
+    }
+    document.addEventListener('visibilitychange', onVisibility)
+
+    return () => {
+      cancelAnimationFrame(rafId)
+      observer.disconnect()
+      document.removeEventListener('visibilitychange', onVisibility)
+    }
+  }, []) // intentionally run once — items are stable server-component props
+
+  if (cards.length === 0) return null
+
+  return (
+    <>
+      {/* Minimal inline keyframe — hides webkit scrollbar without globals.css change */}
+      <style>{`
+        .insights-scroll::-webkit-scrollbar { display: none; }
+      `}</style>
+
+      {/* Outer wrapper carries the edge-fade mask */}
+      <div
+        style={{
+          // Fade 7% on each edge — wide enough to hint at more cards
+          maskImage:       'linear-gradient(to right, transparent 0%, black 7%, black 93%, transparent 100%)',
+          WebkitMaskImage: 'linear-gradient(to right, transparent 0%, black 7%, black 93%, transparent 100%)',
+        }}
+      >
+        <div
+          ref={scrollRef}
+          className="insights-scroll overflow-x-auto"
+          style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}
+          aria-live="off"
+          onMouseEnter={() => { hoverPausedRef.current = true  }}
+          onMouseLeave={() => { hoverPausedRef.current = false }}
+          onFocus={()     => { hoverPausedRef.current = true  }}
+          onBlur={()      => { hoverPausedRef.current = false }}
+        >
+          <div className="flex gap-4 pb-1" style={{ width: 'max-content' }}>
+            {items.map((card, i) => (
+              <div key={i} style={{ width: CARD_W, flexShrink: 0 }}>
+                <InsightCard {...card} />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/frontend/components/TrendingConnections.tsx
+++ b/frontend/components/TrendingConnections.tsx
@@ -1,0 +1,53 @@
+import Link from 'next/link'
+import ActorAvatar from './ActorAvatar'
+
+export interface CollabPairData {
+  actor1: string
+  actor2: string
+  films: number
+  href: string
+}
+
+export default function TrendingConnections({ pairs }: { pairs: CollabPairData[] }) {
+  if (!pairs.length) return null
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+      {pairs.map((pair, i) => (
+        <Link
+          key={i}
+          href={pair.href}
+          className="
+            flex items-center gap-4 px-5 py-4 rounded-2xl
+            border border-white/[0.07] bg-white/[0.03]
+            hover:bg-white/[0.07] hover:border-white/[0.13]
+            transition-all duration-200 group
+          "
+        >
+          {/* Overlapping avatars */}
+          <div className="flex items-center flex-shrink-0">
+            <div className="relative z-10 ring-2 ring-[#0a0a0f] rounded-full">
+              <ActorAvatar name={pair.actor1} size={44} />
+            </div>
+            <div className="-ml-3 ring-2 ring-[#0a0a0f] rounded-full">
+              <ActorAvatar name={pair.actor2} size={44} />
+            </div>
+          </div>
+
+          {/* Names + count */}
+          <div className="flex-1 min-w-0">
+            <p className="text-white text-sm font-semibold truncate">
+              {pair.actor1} <span className="text-white/30">+</span> {pair.actor2}
+            </p>
+            <p className="text-white/40 text-xs mt-0.5">{pair.films} films together</p>
+          </div>
+
+          {/* Arrow */}
+          <span className="text-white/20 group-hover:text-white/55 transition-colors flex-shrink-0">
+            →
+          </span>
+        </Link>
+      ))}
+    </div>
+  )
+}

--- a/frontend/components/stats/ConnectionFinder.tsx
+++ b/frontend/components/stats/ConnectionFinder.tsx
@@ -11,6 +11,7 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react'
 import ActorAvatar from '@/components/ActorAvatar'
+import ConnectionResult from '@/components/ConnectionResult'
 import { searchActors, getActorConnection, type Actor, type ConnectionPath } from '@/lib/api'
 
 // ── Tiny actor search box ─────────────────────────────────────────────────────
@@ -21,12 +22,14 @@ function ActorBox({
   onSelect,
   onClear,
   colorClass,
+  placeholder = 'Search actor…',
 }: {
   label: string
   selected: Actor | null
   onSelect: (a: Actor) => void
   onClear: () => void
   colorClass: string
+  placeholder?: string
 }) {
   const [query, setQuery]     = useState('')
   const [results, setResults] = useState<Actor[]>([])
@@ -88,7 +91,7 @@ function ActorBox({
               ref={inputRef}
               value={query}
               onChange={e => setQuery(e.target.value)}
-              placeholder="Search actor…"
+              placeholder={placeholder}
               className="flex-1 bg-transparent py-3.5 text-white placeholder-white/25 outline-none text-sm"
             />
             {loading && <span className="text-white/30 text-xs animate-pulse flex-shrink-0">…</span>}
@@ -117,55 +120,6 @@ function ActorBox({
           )}
         </div>
       )}
-    </div>
-  )
-}
-
-// ── Path visualisation ────────────────────────────────────────────────────────
-
-function PathDisplay({ result }: { result: ConnectionPath }) {
-  if (!result.found) {
-    return (
-      <div className="text-center py-8">
-        <p className="text-3xl mb-3">🔗</p>
-        <p className="text-white/60 text-sm">No connection found within 6 degrees.</p>
-      </div>
-    )
-  }
-
-  const { path, connections } = result
-
-  return (
-    <div className="mt-6">
-      <p className="text-center text-white/40 text-xs uppercase tracking-widest mb-5">
-        Connected in <span className="text-white font-bold">{result.depth}</span> step{result.depth !== 1 ? 's' : ''}
-      </p>
-
-      {/* Horizontal scroll on mobile, centred on desktop */}
-      <div className="flex items-center gap-0 overflow-x-auto pb-2 justify-start sm:justify-center">
-        {path.map((actor, idx) => (
-          <div key={actor.id} className="flex items-center gap-0 flex-shrink-0">
-            {/* Actor node */}
-            <div className="flex flex-col items-center gap-1.5 px-2">
-              <ActorAvatar name={actor.name} size={52} />
-              <p className="text-white text-xs font-semibold text-center max-w-[80px] leading-tight">
-                {actor.name}
-              </p>
-            </div>
-
-            {/* Connecting film */}
-            {idx < connections.length && (
-              <div className="flex flex-col items-center gap-0.5 px-1 flex-shrink-0 min-w-[90px] max-w-[110px]">
-                <div className="h-px w-full bg-white/20" />
-                <p className="text-white/35 text-[10px] text-center leading-tight px-1 py-0.5">
-                  {connections[idx].movie_title}
-                </p>
-                <div className="h-px w-full bg-white/20" />
-              </div>
-            )}
-          </div>
-        ))}
-      </div>
     </div>
   )
 }
@@ -220,18 +174,13 @@ export default function ConnectionFinder({
   return (
     <section className="rounded-3xl p-6 sm:p-8 border border-white/[0.08]" style={{ background: '#13131a' }}>
       {/* Header */}
-      <div className="flex items-start justify-between gap-4 mb-6">
-        <div>
-          <h2 className="text-white font-bold text-lg flex items-center gap-2">
-            🔗 Actor Connection Finder
-          </h2>
-          <p className="text-white/40 text-sm mt-1">
-            Six degrees of South Indian cinema — find the shortest collaboration path between any two actors
-          </p>
-        </div>
-        <span className="flex-shrink-0 text-[10px] font-bold uppercase tracking-widest text-white/25 border border-white/10 rounded-full px-3 py-1 mt-1">
-          BFS
-        </span>
+      <div className="mb-6">
+        <h2 className="text-white font-bold text-lg flex items-center gap-2">
+          🔗 Actor Connection Finder
+        </h2>
+        <p className="text-white/40 text-sm mt-1">
+          Try connecting actors you wouldn&apos;t expect 👀
+        </p>
       </div>
 
       {/* Actor pickers */}
@@ -242,6 +191,7 @@ export default function ConnectionFinder({
           onSelect={setActor1}
           onClear={() => { setActor1(null); setResult(null) }}
           colorClass="text-amber-400/70"
+          placeholder="Try Rajinikanth"
         />
 
         <div className="flex sm:flex-col items-center justify-center gap-1 flex-shrink-0 py-2">
@@ -256,6 +206,7 @@ export default function ConnectionFinder({
           onSelect={setActor2}
           onClear={() => { setActor2(null); setResult(null) }}
           colorClass="text-cyan-400/70"
+          placeholder="Try Prabhas"
         />
       </div>
 
@@ -263,12 +214,12 @@ export default function ConnectionFinder({
       <div className="mt-5 flex flex-col sm:flex-row items-center gap-3">
         <button
           onClick={handleFind}
-          disabled={!canSearch || loading}
+          disabled={loading}
           className={`
-            px-8 py-3 rounded-full font-semibold text-sm transition-all
+            px-8 py-3 rounded-full font-bold text-sm transition-all duration-200
             ${canSearch && !loading
-              ? 'bg-white text-black hover:bg-white/90 active:scale-95 shadow-lg shadow-white/10'
-              : 'bg-white/10 text-white/30 cursor-not-allowed'}
+              ? 'bg-white text-[#0a0a0f] hover:scale-[1.03] hover:shadow-lg hover:shadow-white/20 active:scale-95'
+              : 'bg-white/[0.08] text-white/50 border border-white/[0.12] cursor-default'}
           `}
         >
           {loading ? 'Searching path…' : 'Find Connection'}
@@ -300,8 +251,13 @@ export default function ConnectionFinder({
         </div>
       )}
 
-      {/* Result */}
-      {result && !loading && <PathDisplay result={result} />}
+      {/* Result — key forces full remount (animation reset) on each new search */}
+      {result && !loading && (
+        <ConnectionResult
+          key={`${result.path[0]?.id}-${result.path.at(-1)?.id}-${result.depth}`}
+          result={result}
+        />
+      )}
     </section>
   )
 }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -66,14 +66,24 @@ export interface TopCollaboration {
 }
 
 export interface Insight {
-  type: 'collaboration' | 'director' | 'supporting'
-  headline: string
-  value: number
+  /** Legacy types: 'collaboration' | 'director' | 'supporting'
+   *  WOW types: 'collab_shock' | 'hidden_dominance' | 'cross_industry'
+   *             | 'career_peak' | 'network_power' | 'director_loyalty' */
+  type: string
+  /** Broad grouping for filtering/diversity: 'collaboration' | 'network' | 'career' | 'industry' */
+  category?: string
+  title: string
+  /** Numeric count for most types; string range (e.g. "2005–2010") for career_peak. */
+  value: number | string
   unit: string
   actors: string[]
   /** Database IDs for the actors[] array — same order. Use for building URLs
    *  without any name→slug conversion (avoids issues with special chars like dots). */
   actor_ids: number[]
+  /** WOW story sentence — the surprising context behind the stat. Undefined for legacy types. */
+  subtext?: string
+  /** Normalised score 0–1. Higher = more surprising / impressive. */
+  confidence?: number
 }
 
 export interface SharedFilm {


### PR DESCRIPTION
Frontend
--------
- HeroSearch: hero search bar with trending actor chips (one per industry)
- ConnectionFinder: animated BFS path replay (ConnectionResult.tsx) · buildItems() interleaves path[] + connections[] into flat Item[] · single setTimeout chain advances step — no interval, no queue · key={actor1-actor2-depth} forces remount on each new search · progress dots; click any past node to replay from that point
- GraphPreview: interactive collaboration network graph · center node r=34, hover reveals film count, "SHOWING NETWORK FOR" label · ?actor= URL param overrides network center (Share button integration)
- InsightsCarousel: infinite-scroll RAF loop, tripled cards, hover-pause
- page.tsx: Hero → Connection Finder → Graph Preview → Insights layout · insight.headline renamed to insight.title (matches backend contract)

Backend — insight_engine.py v3
-------------------------------
- Thread-safe TTL cache (threading.Lock): read under lock, compute outside lock, write under lock — concurrent misses are idempotent
- Smoother confidence curve: score / 100 (was / 50, saturated too fast)
- title field replaces headline across all 6 patterns
- category field added: collaboration | network | career | industry
- api.ts Insight interface updated: headline→title, +category?, +confidence?

## What does this PR do?
-

## Why is this change needed?
-

## Screenshots / Output (if UI)
-

## Checklist
- [ ] Builds locally (or via Docker)
- [ ] No breaking DB changes without discussion
- [ ] Small, focused PR
